### PR TITLE
Modify UI and code structure / minor bug fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "data"]
 	path = data
 	url = git@github.com:SeishoAbe/NucDeEx_ext_data.git
+[submodule "scripts"]
+	path = scripts
+	url = git@github.com:SeishoAbe/NucDeEx_scripts.git

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,10 @@ endif
 LIBDIR=lib
 LIBNAME=${LIBDIR}/libNucDeEx.a
 
-AOBJS =  NucDeExNucleus.o NucDeExNucleusTable.o ReadTALYS.o 
-AOBJS += NucDeExParticle.o NucDeExDeexcitation.o NucDeExUtils.o NucDeExEventInfo.o NucDeExRandom.o
+AOBJS = ReadTALYS.o
+AOBJS += NucDeExNucleus.o NucDeExNucleusTable.o
+AOBJS += NucDeExParticle.o NucDeExUtils.o NucDeExEventInfo.o NucDeExRandom.o
+AOBJS += NucDeExDeexcitationBase.o NucDeExDeexcitationTALYS.o NucDeExDeexcitationPhole.o NucDeExDeexcitation.o
 
 OBJDIR=obj
 OBJS = $(addprefix $(OBJDIR)/,$(AOBJS))

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROGRAMS = plot_decay cout_input #simulation
+PROGRAMS = plot_decay cout_input simulation
 #PROGRAMS += genie
 
 ifndef ROOTSYS
@@ -41,7 +41,7 @@ LIBDIR=lib
 LIBNAME=${LIBDIR}/libNucDeEx.a
 
 AOBJS =  NucDeExNucleus.o NucDeExNucleusTable.o ReadTALYS.o 
-AOBJS += NucDeExParticle.o NucDeExDeexcitation.o NucDeExUtils.o NucDeExEventInfo.o
+AOBJS += NucDeExParticle.o NucDeExDeexcitation.o NucDeExUtils.o NucDeExEventInfo.o NucDeExRandom.o
 
 OBJDIR=obj
 OBJS = $(addprefix $(OBJDIR)/,$(AOBJS))

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ LIBDIR=lib
 LIBNAME=${LIBDIR}/libNucDeEx.a
 
 AOBJS =  NucDeExNucleus.o NucDeExNucleusTable.o ReadTALYS.o 
-AOBJS += NucDeExParticle.o NucDeExDeexcitation.o
+AOBJS += NucDeExParticle.o NucDeExDeexcitation.o NucDeExUtils.o
 
 OBJDIR=obj
 OBJS = $(addprefix $(OBJDIR)/,$(AOBJS))

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PROGRAMS = plot_decay cout_input simulation
-PROGRAMS += genie
+PROGRAMS = plot_decay cout_input #simulation
+#PROGRAMS += genie
 
 ifndef ROOTSYS
 @echo "$(error "Please set ROOT enviromental variables")"
@@ -25,14 +25,14 @@ endif
 
 ## neut libs
 ifdef NEUT_ROOT
-PROGRAMS += neut
+#PROGRAMS += neut
 CXXFLAGS += -I$(NEUT_ROOT)/include
 LDFLAGS += -L$(NEUT_ROOT)/lib -lNEUT -lNEUTClass -lNEUTClassUtils
 endif
 
 ## nuwro libs
 ifdef NUWRO
-PROGRAMS += nuwro
+#PROGRAMS += nuwro
 CXXFLAGS += -I$(NUWRO)/src
 LDFLAGS += $(NUWRO)/bin/event1.so
 endif
@@ -41,7 +41,7 @@ LIBDIR=lib
 LIBNAME=${LIBDIR}/libNucDeEx.a
 
 AOBJS =  NucDeExNucleus.o NucDeExNucleusTable.o ReadTALYS.o 
-AOBJS += NucDeExParticle.o NucDeExDeexcitation.o NucDeExUtils.o
+AOBJS += NucDeExParticle.o NucDeExDeexcitation.o NucDeExUtils.o NucDeExEventInfo.o
 
 OBJDIR=obj
 OBJS = $(addprefix $(OBJDIR)/,$(AOBJS))

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROGRAMS = plot_decay cout_input simulation
-#PROGRAMS += genie
+PROGRAMS += genie
 
 ifndef ROOTSYS
 @echo "$(error "Please set ROOT enviromental variables")"
@@ -13,10 +13,8 @@ ARFLAGS=
 
 ## for cern root
 CXXFLAGS        += $(shell root-config --cflags)
-#LDFLAGS         += $(shell root-config --libs) # <- Print regular ROOT libraries
-#LDFLAGS         += $(shell root-config --glibs) # <- Print regular + GUI ROOT libraries
-#LDFLAGS         += $(shell root-config --evelibs) # <- Print regular + GUI + Eve libraries. SHOULD BE THIS!
-LDFLAGS         += $(shell root-config --libs) -lEG -lGeom #-lEve
+LDFLAGS         += $(shell root-config --libs) -lEG -lGeom #-lEve 
+# DO NOT link lEve. -lEG and -lGeom are necessary.
 ROOTVERSION = $(shell root-config --version)
 ROOT5=$(findstring 5.,$(ROOTVERSION))
 ifneq ($(ROOT5),)
@@ -25,14 +23,14 @@ endif
 
 ## neut libs
 ifdef NEUT_ROOT
-#PROGRAMS += neut
+PROGRAMS += neut
 CXXFLAGS += -I$(NEUT_ROOT)/include
 LDFLAGS += -L$(NEUT_ROOT)/lib -lNEUT -lNEUTClass -lNEUTClassUtils
 endif
 
 ## nuwro libs
 ifdef NUWRO
-#PROGRAMS += nuwro
+PROGRAMS += nuwro
 CXXFLAGS += -I$(NUWRO)/src
 LDFLAGS += $(NUWRO)/bin/event1.so
 endif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Nuclear Deexcitation Simulator (NucDeEx)
-NUcDeEx is a nuclear deexcitation simulator for neutrino interactions and nucleon decays shared in [GitHub](https://github.com/SeishoAbe/NucDeEx).  
+NucDeEx is a nuclear deexcitation simulator for neutrino interactions and nucleon decays shared in [GitHub](https://github.com/SeishoAbe/NucDeEx).  
 It is composed of two parts: [TALYS v1.96](https://tendl.web.psi.ch/tendl_2019/talys.html) and a kinematics simulator based on [ROOT](https://root.cern/).  
 Note that this simulator reads files containing branching ratios calculated with TALYS.  
 Therefore, the simulator codes themselves are independent of the TALYS code.
@@ -84,14 +84,7 @@ An example code for simulation is provided:
 
 ## TALYS information & calculation
 - The branching ratios are calculated using [TALYS v1.96](https://tendl.web.psi.ch/tendl_2019/talys.html).
-- If you want to use TALYS, please follow the documents in tar and install it. 
-- Then, you can use the following scripts and codes 
-```
- run_talys.sh
- ./bin/plot_decay
-```
-- `./bin/plot_decay` is an analyzer on TALYS output.
-- The files created by this executable are used in the simulator (`./bin/simulation`).
+- `main/plot_decay.cc` is the tool to analyze TALYS's output. This is very messy script...
 
 ## Interfaces and build scripts for INCLXX and Geant4
 NucDeEx also provides intefaces and build scripts for use in [INCL++](https://irfu.cea.fr/dphn/Spallation/incl.html) and [Geant4](https://geant4.web.cern.ch/).
@@ -110,7 +103,8 @@ NucDeEx also provides intefaces and build scripts for use in [INCL++](https://ir
 - `./bin`: Executables
 - `./lib`: Library directory
 - `./obj`: Object file directory
-- `./macro`: ROOT macro files to check the output. This is a private submodule.
+- `./macro`: ROOT macro files to check the output (private)
+- `./scripts`: Contains shell scripts for execution (private)
 
 ### Tables, output, etc.
 - `./output`
@@ -128,7 +122,7 @@ NucDeEx also provides intefaces and build scripts for use in [INCL++](https://ir
   - `./sf`
 	- Benhar SF used in event simulation
 - `./data`
-  - Reference data (other predictions, experimental data) are stored. A private submodule.
+  - Reference external data, both experimental and predictive) are stored (private)
 - `./inclxx`
   - Build scripts for use in INCLXX.
 - `./geant4`

--- a/include/G4NucDeExInterface.hh
+++ b/include/G4NucDeExInterface.hh
@@ -65,7 +65,7 @@ public:
 private:
   NucDeExDeexcitation *theNucDeEx;
   G4VPreCompoundModel *theG4PreCompound;
-  int Zt,Nt,At,verbose;
+  int Zt,Nt,At;
   TVector3 Pinit;
 
   std::vector<NucDeExParticle> *theNucDeExResult;

--- a/include/NucDeExConsts.hh
+++ b/include/NucDeExConsts.hh
@@ -4,18 +4,17 @@
 #include <string>
 
 namespace NucDeEx{
+  const int bins=100;
+  const int parity=2;
 
-  static const int bins=100;
-  static const int parity=2;
-
-  static const int num_particle=7;
-  static const std::string particle_name[num_particle]
+  const int num_particle=7;
+  const std::string particle_name[num_particle]
     = {"gamma","neutron","proton",
        "deuteron", "triton","helium-3","alpha"};
-  static const int PDG_particle[num_particle]
+  const int PDG_particle[num_particle]
     = {22, 2112, 2212,
        1000010020, 1000010030, 1000020030,1000020040};
-  static const int color_root[num_particle]
+  const int color_root[num_particle]
     = {880+1, // violet+1
        600, // bule
        632, // red
@@ -24,8 +23,7 @@ namespace NucDeEx{
        416+1,// green+1
        616 // magenta
       };
-  static const double amu_c2 =  931.494028 ;
+  const double amu_c2 =  931.494028 ;
   // copied from TGeoPhysicalConstants.h (root v6. absent in v5)
-
 }
 #endif

--- a/include/NucDeExDeexcitation.hh
+++ b/include/NucDeExDeexcitation.hh
@@ -6,14 +6,9 @@
 #include <sstream>
 #include <vector>
 
-#include "NucDeExConsts.hh"
 #include "NucDeExDeexcitationBase.hh"
 #include "NucDeExDeexcitationTALYS.hh"
 #include "NucDeExDeexcitationPhole.hh"
-
-#include <TFile.h>
-#include <TGraph.h>
-#include <TParticle.h>
 
 #ifdef INCL_DEEXCITATION_NUCDEEX
 #include "G4INCLConfig.hh"

--- a/include/NucDeExDeexcitation.hh
+++ b/include/NucDeExDeexcitation.hh
@@ -9,6 +9,7 @@
 #include "NucDeExConsts.hh"
 #include "NucDeExNucleusTable.hh"
 #include "NucDeExParticle.hh"
+#include "NucDeExEventInfo.hh"
 
 #include <TFile.h>
 #include <TGraph.h>
@@ -33,9 +34,9 @@ class NucDeExDeexcitation{
   virtual ~NucDeExDeexcitation();
 
   // --- Main function ---//
-  int DoDeex(const int Zt, const int Nt,
-              const int Z, const int N, const int shell, const double Ex,
-             const TVector3& mom=TVector3(0,0,0));
+  const NucDeExEventInfo DoDeex(const int Zt, const int Nt,
+                          const int Z, const int N, const int shell, const double Ex,
+                          const TVector3& mom=TVector3(0,0,0));
   // Zt, Nt  : Target nucleus Z and N (supports 16O or 12C currently)
   // Z, N    : Residual nucleus Z and N (having excitation energy)
   // shell  0 : Shell level will be determined according to Ex (box cut)
@@ -67,22 +68,18 @@ class NucDeExDeexcitation{
   // only for single-nucleon disappearance
   int DoDeex_p32(const int Zt, const int Nt,
                  const int Z, const int N,
-                 const TVector3& mom=TVector3(0,0,0));
-  // Note: Energy level is determined irrelevant to Ex
+                 const TVector3& mom=TVector3(0,0,0)); // Note: Energy level is determined irrelevant to Ex
   // return  1: Sucess
   //        -1 : Fatal error
   
   int ExtoShell(const int Zt, const int Nt, const double Ex);
 
-  TRandom3* GetTRandom3(){ return rndm; };
   void SetEventID(int id){ eventID=id;};
   int  GetEventID(){ return eventID; };
-  vector<NucDeExParticle>* GetParticleVector(){return _particle;};
   NucDeExNucleusTable* GetNucleusTablePtr(){ return _nucleus_table;};
   int GetShell(){return _shell;};
 
   private:
-  void Init();
 
   // --- Simulation method called by DoDeex() --- //
   int DecayMode(const double Ex);
@@ -137,9 +134,6 @@ class NucDeExDeexcitation{
   double mass_particle;
   TVector3 mom_particle;
 
-  // for output
-  void InitParticleVector();
-  vector<NucDeExParticle> *_particle;
 
   // others
   NucDeExNucleusTable* _nucleus_table;
@@ -149,6 +143,8 @@ class NucDeExDeexcitation{
   std::ostringstream os;
   const double check_criteria=5e-3;
   int _shell;
+  void Init();
+  NucDeExEventInfo EventInfo;
 
   // Constatnts for Ex to shell
   const double Ex_12C_s12=16.0;

--- a/include/NucDeExDeexcitation.hh
+++ b/include/NucDeExDeexcitation.hh
@@ -13,7 +13,6 @@
 
 #include <TFile.h>
 #include <TGraph.h>
-#include <TRandom3.h>
 #include <TDatabasePDG.h>
 #include <TParticle.h>
 #include <TGeoManager.h>
@@ -103,7 +102,6 @@ class NucDeExDeexcitation{
 
   TGraph* g_br[NucDeEx::num_particle];
   TGraph* g_br_ex;
-  TRandom3* rndm;
   TDatabasePDG* pdg;
   TGeoManager* geo;
   TGeoElementTable* element_table;

--- a/include/NucDeExDeexcitation.hh
+++ b/include/NucDeExDeexcitation.hh
@@ -24,10 +24,11 @@
 
 class NucDeExDeexcitation{
   public:
-  NucDeExDeexcitation(const int ldmodel=1, const bool parity_optmodall=1);
+  NucDeExDeexcitation(const int ld=1, const bool p_o=1);
 #ifdef INCL_DEEXCITATION_NUCDEEX
-  NucDeExDeexcitation(const int ldmodel=1, const bool parity_optmodall=1, G4INCL::Config *config=0);
+  NucDeExDeexcitation(const int ld=1, const bool p_o=1, G4INCL::Config *config=0);
 #endif
+  // ld: ldmodel, p_o: parity_optmodall
 
   virtual ~NucDeExDeexcitation();
 
@@ -73,10 +74,7 @@ class NucDeExDeexcitation{
   
   int ExtoShell(const int Zt, const int Nt, const double Ex);
 
-  void SetSeed(int s){ rndm->SetSeed(s) ;};
-  int  GetSeed(){return rndm->GetSeed();};
   TRandom3* GetTRandom3(){ return rndm; };
-  void SetVerbose(const int v);
   void SetEventID(int id){ eventID=id;};
   int  GetEventID(){ return eventID; };
   vector<NucDeExParticle>* GetParticleVector(){return _particle;};
@@ -84,7 +82,7 @@ class NucDeExDeexcitation{
   int GetShell(){return _shell;};
 
   private:
-  void Init(const int ldmodel, const bool parity_optmodall);
+  void Init();
 
   // --- Simulation method called by DoDeex() --- //
   int DecayMode(const double Ex);
@@ -147,7 +145,6 @@ class NucDeExDeexcitation{
   NucDeExNucleusTable* _nucleus_table;
   int ldmodel;
   bool parity_optmodall;
-  int verbose;
   int eventID;
   std::ostringstream os;
   const double check_criteria=5e-3;
@@ -180,7 +177,5 @@ class NucDeExDeexcitation{
   const double E_p32_15O[Nlevel_p32_15O]={6.18,9.61,10.48};
   const double Br_p32_15O[Nlevel_p32_15O]={0.872,0.064,0.064}; // guess
   //const double Br_p32_15O[Nlevel_p32_15O]={1.,0,0}; // original Ejiri's value
-
-  std::string PATH_NucDeEx_root;
 };
 #endif

--- a/include/NucDeExDeexcitationBase.hh
+++ b/include/NucDeExDeexcitationBase.hh
@@ -30,7 +30,7 @@ class NucDeExDeexcitationBase{
                           const TVector3& mom);
 
   bool Decay(const bool breakflag);
-    // Calculate two-body decay considering lorentz boost
+    // Calculate two-body decay considering Lorentz boost
     // return: 1->OK. 0->suspicious
   
   void AddGSNucleus(const int Z, const int N, const TVector3& mom=TVector3(0,0,0));
@@ -56,23 +56,20 @@ class NucDeExDeexcitationBase{
   // decay particle info
   double mass_particle;
   TVector3 mom_particle;
-  
-  // basic decay inofo
+  // decay info
   int decay_mode;
   double S;
   double Qvalue;
 
-
-  // scoring 
+  // --- scoring --- //
   NucDeExEventInfo EventInfo;
   int EventID;
   
-  // utils
+  // --- utils --- //
   TDatabasePDG* fTDatabasePDG;
   TGeoManager* fTGeoManager;
   TGeoElementTable* fTGeoElementTable;
   std::ostringstream os;
-
   const double check_criteria=5e-3;
 };
 #endif

--- a/include/NucDeExDeexcitationBase.hh
+++ b/include/NucDeExDeexcitationBase.hh
@@ -1,0 +1,78 @@
+#ifndef __NUCDEEXDEEXCITATIONBASE__HH__
+#define __NUCDEEXDEEXCITATIONBASE__HH__
+
+#include <string>
+#include <ostream>
+#include <sstream>
+#include <vector>
+
+#include "NucDeExEventInfo.hh"
+#include "NucDeExNucleus.hh"
+
+#include <TDatabasePDG.h>
+#include <TGeoManager.h>
+#include <TGeoElement.h>
+
+#ifdef INCL_DEEXCITATIONBASE_NUCDEEX
+#include "G4INCLConfig.hh"
+#endif
+
+class NucDeExDeexcitationBase{
+  public:
+  NucDeExDeexcitationBase();
+  virtual ~NucDeExDeexcitationBase();
+
+  protected:
+  void Init();
+
+  void SaveEventLevelInfo(const int Zt, const int Nt,
+                          const int Z, const int N,const double Ex, 
+                          const TVector3& mom);
+
+  bool Decay(const bool breakflag);
+    // Calculate two-body decay considering lorentz boost
+    // return: 1->OK. 0->suspicious
+  
+  void AddGSNucleus(const int Z, const int N, const TVector3& mom=TVector3(0,0,0));
+  const double ElementMassInMeV(const int A, const int Z);
+  const double ElementMassInMeV(const TGeoElementRN* ele);
+  const int PDGion(const int Z, const int N); // Z, N to PDG
+
+  //--- params --- //
+  // target nucleus info
+  int Z_target, N_target;
+  double Ex_target;
+  double mass_target;
+  TVector3 mom_target;
+  NucDeExNucleus* nuc_target;
+  std::string name_target;
+  // daughter nucleus info
+  int Z_daughter, N_daughter;
+  double Ex_daughter;
+  double mass_daughter;
+  TVector3 mom_daughter;
+  NucDeExNucleus* nuc_daughter;
+  std::string name_daughter;
+  // decay particle info
+  double mass_particle;
+  TVector3 mom_particle;
+  
+  // basic decay inofo
+  int decay_mode;
+  double S;
+  double Qvalue;
+
+
+  // scoring 
+  NucDeExEventInfo EventInfo;
+  int EventID;
+  
+  // utils
+  TDatabasePDG* fTDatabasePDG;
+  TGeoManager* fTGeoManager;
+  TGeoElementTable* fTGeoElementTable;
+  std::ostringstream os;
+
+  const double check_criteria=5e-3;
+};
+#endif

--- a/include/NucDeExDeexcitationBase.hh
+++ b/include/NucDeExDeexcitationBase.hh
@@ -9,10 +9,6 @@
 #include "NucDeExEventInfo.hh"
 #include "NucDeExNucleus.hh"
 
-#include <TDatabasePDG.h>
-#include <TGeoManager.h>
-#include <TGeoElement.h>
-
 #ifdef INCL_DEEXCITATIONBASE_NUCDEEX
 #include "G4INCLConfig.hh"
 #endif
@@ -66,9 +62,6 @@ class NucDeExDeexcitationBase{
   int EventID;
   
   // --- utils --- //
-  TDatabasePDG* fTDatabasePDG;
-  TGeoManager* fTGeoManager;
-  TGeoElementTable* fTGeoElementTable;
   std::ostringstream os;
   const double check_criteria=5e-3;
 };

--- a/include/NucDeExDeexcitationBase.hh
+++ b/include/NucDeExDeexcitationBase.hh
@@ -19,8 +19,6 @@ class NucDeExDeexcitationBase{
   virtual ~NucDeExDeexcitationBase();
 
   protected:
-  void Init();
-
   void SaveEventLevelInfo(const int Zt, const int Nt,
                           const int Z, const int N,const double Ex, 
                           const TVector3& mom);

--- a/include/NucDeExDeexcitationPhole.hh
+++ b/include/NucDeExDeexcitationPhole.hh
@@ -25,13 +25,11 @@ class NucDeExDeexcitationPhole: public NucDeExDeexcitationBase{
                           const TVector3& mom=TVector3(0,0,0));
     // Note: Energy level is determined irrelevant to Ex
 
-
   void SetPtrTALYS(NucDeExDeexcitationTALYS* t){deex_talys = t;};
 
   private:
   int flag_model;
   NucDeExDeexcitationTALYS* deex_talys;
-  
 
   // Constants for (p3/2)-1 Br
   // 11B* (Panin et al., Phys. Lett. B 753 204-210. Experimental data)

--- a/include/NucDeExDeexcitationPhole.hh
+++ b/include/NucDeExDeexcitationPhole.hh
@@ -1,0 +1,59 @@
+#ifndef __NUCDEEXDEEXCITATIONPHOLE__HH__
+#define __NUCDEEXDEEXCITATIONPHOLE__HH__
+
+#include <string>
+#include <ostream>
+#include <sstream>
+#include <vector>
+
+#include "NucDeExConsts.hh"
+#include "NucDeExDeexcitationBase.hh"
+#include "NucDeExDeexcitationTALYS.hh"
+
+class NucDeExDeexcitationPhole: public NucDeExDeexcitationBase{
+  public:
+  NucDeExDeexcitationPhole();
+  NucDeExDeexcitationPhole(int f);
+    // 11B* and 11C* are common (Panin et al., Phys. Lett. B 753 204-210. Experimental data)
+    // 15N* and 15O* are as follows:
+    //  0 -> Based on Ejili, Phys. Rev. C 58, 3
+    //  1 -> Based on Yosoi (D-thesis)
+  ~NucDeExDeexcitationPhole(){};
+
+  NucDeExEventInfo DoDeex(const int Zt, const int Nt,
+                          const int Z, const int N, const double Ex,
+                          const TVector3& mom=TVector3(0,0,0));
+    // Note: Energy level is determined irrelevant to Ex
+
+
+  void SetPtrTALYS(NucDeExDeexcitationTALYS* t){deex_talys = t;};
+
+  private:
+  int flag_model;
+  NucDeExDeexcitationTALYS* deex_talys;
+  
+
+  // Constants for (p3/2)-1 Br
+  // 11B* (Panin et al., Phys. Lett. B 753 204-210. Experimental data)
+  static const int Nlevel_p32_11B = 3; 
+  const double E_p32_11B[Nlevel_p32_11B]={0.,2.125,5.020};
+  const double Br_p32_11B[Nlevel_p32_11B]={0.82,0.10,0.08};
+  // 11C* (assume analogy of 11B*)
+  //      the same Br, but energy is different
+  static const int Nlevel_p32_11C = 3;
+  const double E_p32_11C[Nlevel_p32_11C]={0.,2.000,4.804};
+  const double Br_p32_11C[Nlevel_p32_11C]={0.82,0.10,0.08};
+
+  // 15N* (Ejili, Phys. Rev. C 58, 3)
+  //     Deexcitation from 9.93 MeV will be described from TALYS data
+  //     Deexcitation from 10.70 is taken from Ejiri (100% proton)
+  static const int Nlevel_p32_15N = 3;
+  const double E_p32_15N[Nlevel_p32_15N]={6.32,9.93,10.70};
+  const double Br_p32_15N[Nlevel_p32_15N]={0.872,0.064,0.064};
+  // 15O* (Ejiri , Phys. Rev. C 58, 3)
+  static const int Nlevel_p32_15O=3;
+  const double E_p32_15O[Nlevel_p32_15O]={6.18,9.61,10.48};
+  const double Br_p32_15O[Nlevel_p32_15O]={0.872,0.064,0.064}; // guess
+  //const double Br_p32_15O[Nlevel_p32_15O]={1.,0,0}; // original Ejiri's value
+};
+#endif

--- a/include/NucDeExDeexcitationTALYS.hh
+++ b/include/NucDeExDeexcitationTALYS.hh
@@ -28,15 +28,10 @@ class NucDeExDeexcitationTALYS: public NucDeExDeexcitationBase{
 
   NucDeExEventInfo DoDeex(const int Zt, const int Nt,
                           const int Z, const int N, const double Ex,
-                          //const int Z, const int N, const int shell, const double Ex,
                           const TVector3& mom=TVector3(0,0,0));
   // Zt, Nt  : Target nucleus Z and N (supports 16O or 12C currently)
   // Z, N    : Residual nucleus Z and N (having excitation energy)
-  // shell  0 : Shell level will be determined according to Ex (box cut)
-  //        1 : s1/2-hole
-  //        2 : p3/2-hole
-  //        3 : p1/2-hole (only for 16O target)
-  // Ex      : Only used if shell==1
+  // Ex      : Excitation energy
   // mom     : 3D momentum of residual nucleus
 
   private:

--- a/include/NucDeExDeexcitationTALYS.hh
+++ b/include/NucDeExDeexcitationTALYS.hh
@@ -1,0 +1,61 @@
+#ifndef __NUCDEEXDEEXCITATIONTALYS__HH__
+#define __NUCDEEXDEEXCITATIONTALYS__HH__
+
+#include <string>
+#include <ostream>
+#include <sstream>
+#include <vector>
+
+#include "NucDeExConsts.hh"
+#include "NucDeExDeexcitationBase.hh"
+
+#include <TFile.h>
+#include <TGraph.h>
+#include <TParticle.h>
+
+#ifdef INCL_DEEXCITATION_NUCDEEX
+#include "G4INCLConfig.hh"
+#endif
+
+class NucDeExDeexcitationTALYS: public NucDeExDeexcitationBase{
+  public:
+  NucDeExDeexcitationTALYS();
+  NucDeExDeexcitationTALYS(const int ld=1, const bool p_o=1);
+#ifdef INCL_DEEXCITATION_NUCDEEX
+  NucDeExDeexcitationTALYS(const int ld=1, const bool p_o=1, G4INCL::Config *config=0);
+#endif
+  virtual ~NucDeExDeexcitationTALYS(){};
+
+  NucDeExEventInfo DoDeex(const int Zt, const int Nt,
+                          const int Z, const int N, const double Ex,
+                          //const int Z, const int N, const int shell, const double Ex,
+                          const TVector3& mom=TVector3(0,0,0));
+  // Zt, Nt  : Target nucleus Z and N (supports 16O or 12C currently)
+  // Z, N    : Residual nucleus Z and N (having excitation energy)
+  // shell  0 : Shell level will be determined according to Ex (box cut)
+  //        1 : s1/2-hole
+  //        2 : p3/2-hole
+  //        3 : p1/2-hole (only for 16O target)
+  // Ex      : Only used if shell==1
+  // mom     : 3D momentum of residual nucleus
+
+  private:
+  int DecayMode(const double Ex);
+
+  // --- ROOT related methods & members --- //
+  bool OpenROOT(const int Zt,const int Nt, const int Z, const int N);
+  bool GetBrTGraph(const std::string st);
+  int  GetBrExTGraph(const std::string st, const double ex_t, const int mode); 
+  bool DaughterExPoint(double *d_Ex, int *d_point); //call by pointer
+    // The nearest TGraph point will be returned
+  void DeleteTGraphs();
+
+  TFile* rootf;
+  TGraph* g_br[NucDeEx::num_particle];
+  TGraph* g_br_ex;
+
+  int ldmodel;
+  bool parity_optmodall;
+
+};
+#endif

--- a/include/NucDeExEventInfo.hh
+++ b/include/NucDeExEventInfo.hh
@@ -1,0 +1,23 @@
+#ifndef __NUCDEEXEVENTINFO__HH__
+#define __NUCDEEXEVENTINFO__HH__
+
+#include <vector>
+
+#include "NucDeExParticle.hh"
+
+class NucDeExEventInfo{
+  public:
+  NucDeExEventInfo();
+  ~NucDeExEventInfo();
+
+  void InitParameters();
+
+  // event level info
+  int eventID, fStatus, fShell;
+  int Zt, Nt, Z, N;
+  double Ex, S, MissE;
+  TVector3 Pinit; // Initial momentum of nucleus
+  // particle level info
+  std::vector<NucDeExParticle>* ParticleVector;
+};
+#endif

--- a/include/NucDeExEventInfo.hh
+++ b/include/NucDeExEventInfo.hh
@@ -13,10 +13,15 @@ class NucDeExEventInfo{
   void InitParameters();
 
   // event level info
-  int eventID, fStatus, fShell;
+  int EventID, fStatus, fShell;
+  // fStatus:
+  //     1: OK
+  //     0: The nucleus is not supported
+  //    -1: Fatal
   int Zt, Nt, Z, N;
-  double Ex, S, MissE;
+  double Ex;
   TVector3 Pinit; // Initial momentum of nucleus
+
   // particle level info
   std::vector<NucDeExParticle> ParticleVector;
 };

--- a/include/NucDeExEventInfo.hh
+++ b/include/NucDeExEventInfo.hh
@@ -18,6 +18,6 @@ class NucDeExEventInfo{
   double Ex, S, MissE;
   TVector3 Pinit; // Initial momentum of nucleus
   // particle level info
-  std::vector<NucDeExParticle>* ParticleVector;
+  std::vector<NucDeExParticle> ParticleVector;
 };
 #endif

--- a/include/NucDeExNucleusTable.hh
+++ b/include/NucDeExNucleusTable.hh
@@ -5,22 +5,14 @@
 
 #include "NucDeExNucleus.hh"
 
-#ifdef INCL_DEEXCITATION_NUCDEEX
-#include "G4INCLConfig.hh"
-#endif
-
 class NucDeExNucleusTable{
   public:
   NucDeExNucleusTable();
-#ifdef INCL_DEEXCITATION_NUCDEEX
-  NucDeExNucleusTable(G4INCL::Config *config);
-#endif
   virtual ~NucDeExNucleusTable(){;};
 
   bool ReadTables(const bool init_flag=1);
   int getID(const char* name);
   int GetNumofNuc(){return num_of_nuc;};
-  void SetVerbose(const int v){verbose=v;};
   
   NucDeExNucleus* GetNucleusPtr(const char* name);
   NucDeExNucleus* GetNucleusPtr(int id);
@@ -34,7 +26,5 @@ class NucDeExNucleusTable{
   NucDeExNucleus* _nucleus;
   std::map<std::string, int> _nucleus_id;
   std::map<std::string, int> :: iterator _p_id;
-  std::string PATH_NucDeEx_table;
-  int verbose;
 };
 #endif

--- a/include/NucDeExNucleusTable.hh
+++ b/include/NucDeExNucleusTable.hh
@@ -24,6 +24,7 @@ class NucDeExNucleusTable{
 
   private:
   int num_of_nuc;
+  bool flag_read;
   NucDeExNucleus* _nucleus;
   std::map<std::string, int> _nucleus_id;
   std::map<std::string, int> :: iterator _p_id;

--- a/include/NucDeExNucleusTable.hh
+++ b/include/NucDeExNucleusTable.hh
@@ -11,6 +11,7 @@ class NucDeExNucleusTable{
   virtual ~NucDeExNucleusTable(){;};
 
   bool ReadTables(const bool init_flag=1);
+    // 1 -> new arraies
   int getID(const char* name);
   int GetNumofNuc(){return num_of_nuc;};
   

--- a/include/NucDeExParticle.hh
+++ b/include/NucDeExParticle.hh
@@ -10,8 +10,7 @@ class NucDeExParticle{
   public:
   NucDeExParticle();
   NucDeExParticle(const int PDG,const double mass, const TVector3& mom,
-           const string name, const bool flag=1, const double Ex=0,
-           const int v=1);
+           const string name, const bool flag=1, const double Ex=0);
     // TVector3 is called by referecnce
   ~NucDeExParticle(){;};
   
@@ -34,6 +33,5 @@ class NucDeExParticle{
 
   private:
   const double check_criteria=1e-3;
-  int verbose;
 };
 #endif

--- a/include/NucDeExParticle.hh
+++ b/include/NucDeExParticle.hh
@@ -32,6 +32,6 @@ class NucDeExParticle{
   // This shoud be zero if _flag==1.
 
   private:
-  const double check_criteria=1e-3;
+  double check_criteria=1e-3; // Should not be "const"
 };
 #endif

--- a/include/NucDeExRandom.hh
+++ b/include/NucDeExRandom.hh
@@ -1,0 +1,13 @@
+#ifndef __NUCDEEXRANDOM__HH__
+#define __NUCDEEXRANDOM__HH__
+
+#include <TRandom3.h>
+
+namespace NucDeEx{
+  namespace Random{
+    TRandom3* rndm = NULL;
+    double random();
+  }
+}
+
+#endif

--- a/include/NucDeExRandom.hh
+++ b/include/NucDeExRandom.hh
@@ -5,9 +5,11 @@
 
 namespace NucDeEx{
   namespace Random{
-    TRandom3* rndm = NULL;
+    extern TRandom3 rndm;
+    // needs "extern". These are defined in *.cc
+
     double random();
+    void SetSeed(int s);
   }
 }
-
 #endif

--- a/include/NucDeExUtils.hh
+++ b/include/NucDeExUtils.hh
@@ -4,11 +4,12 @@
 #ifdef INCL_DEEXCITATION_NUCDEEX
 #include "G4INCLConfig.hh"
 #endif
-#include "NucDeExRandom.hh"
+#include "NucDeExNucleusTable.hh"
 
 namespace NucDeEx{
   namespace Utils{
     extern int fVerbose;
+    extern NucDeExNucleusTable* NucleusTable;
     extern std::string NUCDEEX_ROOT;
     // needs "extern". These are defined in *.cc
 

--- a/include/NucDeExUtils.hh
+++ b/include/NucDeExUtils.hh
@@ -1,17 +1,27 @@
 #ifndef __NUCDEEXUTILS__HH__
 #define __NUCDEEXUTILS__HH__
 
+#include <TDatabasePDG.h>
+#include <TGeoManager.h>
+#include <TGeoElement.h>
+
+#include "NucDeExNucleusTable.hh"
+
 #ifdef INCL_DEEXCITATION_NUCDEEX
 #include "G4INCLConfig.hh"
 #endif
-#include "NucDeExNucleusTable.hh"
 
 namespace NucDeEx{
   namespace Utils{
     extern int fVerbose;
     extern NucDeExNucleusTable* NucleusTable;
     extern std::string NUCDEEX_ROOT;
+    extern TDatabasePDG* fTDatabasePDG;
+    extern TGeoManager* fTGeoManager;
+    extern TGeoElementTable* fTGeoElementTable;
     // needs "extern". These are defined in *.cc
+
+    void Init();
 
     void SetPATH();
 #ifdef INCL_DEEXCITATION_NUCDEEX

--- a/include/NucDeExUtils.hh
+++ b/include/NucDeExUtils.hh
@@ -1,0 +1,31 @@
+#ifndef __NUCDEEXUTILS__HH__
+#define __NUCDEEXUTILS__HH__
+
+#ifdef INCL_DEEXCITATION_NUCDEEX
+#include "G4INCLConfig.hh"
+#endif
+
+
+class NucDeExUtils{
+  public:
+  NucDeExUtils(){;}
+  ~NucDeExUtils(){;}
+
+  static void SetVerbose(int v){ fVerbose = v; };
+  static int  GetVerbose(){ return fVerbose; };
+  static void SetSeed(int v){ fSeed = v; };
+  static int  GetSeed(){ return fSeed; };
+
+  static void SetPATH();
+#ifdef INCL_DEEXCITATION_NUCDEEX
+  static void SetPATH(G4INCL::Config* config);
+#endif
+  static std::string GetPATH(){ return NUCDEEX_ROOT; };
+
+  private:
+  static int fVerbose;
+  static int fSeed;
+  static std::string NUCDEEX_ROOT;
+  // Equivalent to env $NUCDEEX_ROOT for standalone use
+};
+#endif

--- a/include/NucDeExUtils.hh
+++ b/include/NucDeExUtils.hh
@@ -4,28 +4,18 @@
 #ifdef INCL_DEEXCITATION_NUCDEEX
 #include "G4INCLConfig.hh"
 #endif
+#include "NucDeExRandom.hh"
 
+namespace NucDeEx{
+  namespace Utils{
+    extern int fVerbose;
+    extern std::string NUCDEEX_ROOT;
+    // needs "extern". These are defined in *.cc
 
-class NucDeExUtils{
-  public:
-  NucDeExUtils(){;}
-  ~NucDeExUtils(){;}
-
-  static void SetVerbose(int v){ fVerbose = v; };
-  static int  GetVerbose(){ return fVerbose; };
-  static void SetSeed(int v){ fSeed = v; };
-  static int  GetSeed(){ return fSeed; };
-
-  static void SetPATH();
+    void SetPATH();
 #ifdef INCL_DEEXCITATION_NUCDEEX
-  static void SetPATH(G4INCL::Config* config);
+    void SetPATH(G4INCL::Config* config);
 #endif
-  static std::string GetPATH(){ return NUCDEEX_ROOT; };
-
-  private:
-  static int fVerbose;
-  static int fSeed;
-  static std::string NUCDEEX_ROOT;
-  // Equivalent to env $NUCDEEX_ROOT for standalone use
-};
+  }
+}
 #endif

--- a/include/ReadTALYS.hh
+++ b/include/ReadTALYS.hh
@@ -14,13 +14,11 @@ class ReadTALYS{
   virtual ~ReadTALYS(){;};
 
   bool Read();
-  void SetVerboseLevel(int v){ _verbose = v;};
 
   private:
   std::string _filename;
   NucDeExNucleusTable* _nucleus_table;
   std::ifstream* _ifs;
-  int _verbose;
 
   const float check_criteria=0.05;
 

--- a/main/genie.cc
+++ b/main/genie.cc
@@ -12,6 +12,7 @@
 #include "TLegend.h"
 #include "THStack.h"
 
+#include "NucDeExUtils.hh"
 #include "NucDeExNucleusTable.hh"
 #include "NucDeExDeexcitation.hh"
 
@@ -39,9 +40,10 @@ int main(int argc, char* argv[]){
   // --- prepare deex tools
   int Zt=0, Nt=0;
   double S;
+  // Set params before declaring NucDeExDeexcitation
+  NucDeExUtils::SetVerbose(2);
+  NucDeExUtils::SetSeed(seed);
   NucDeExDeexcitation* deex = new NucDeExDeexcitation(2, 1);
-  deex->SetSeed(seed);
-  deex->SetVerbose(1);
   NucDeExNucleusTable* nucleus_table = deex->GetNucleusTablePtr();
   bool flag_O=0;
   if(target.find("C")!=string::npos){

--- a/main/neut.cc
+++ b/main/neut.cc
@@ -16,6 +16,7 @@
 #include "neutvect.h"
 #include "neutpart.h"
 
+#include "NucDeExUtils.hh"
 #include "NucDeExNucleusTable.hh"
 #include "NucDeExDeexcitation.hh"
 
@@ -36,9 +37,10 @@ int main(int argc, char* argv[]){
   // --- prepare deex tools
   int Zt=0, Nt=0;
   double S;
+  // Set params before declaring NucDeExDeexcitation
+  NucDeExUtils::SetVerbose(2);
+  NucDeExUtils::SetSeed(seed);
   NucDeExDeexcitation* deex = new NucDeExDeexcitation(2, 1);
-  deex->SetSeed(seed);
-  deex->SetVerbose(1);
   NucDeExNucleusTable* nucleus_table = deex->GetNucleusTablePtr();
   bool flag_O=0;
   if(prefix.find("_C_")!=string::npos){

--- a/main/neut.cc
+++ b/main/neut.cc
@@ -17,8 +17,9 @@
 #include "neutpart.h"
 
 #include "NucDeExUtils.hh"
-#include "NucDeExNucleusTable.hh"
+#include "NucDeExRandom.hh"
 #include "NucDeExDeexcitation.hh"
+#include "NucDeExEventInfo.hh"
 
 using namespace std;
 int main(int argc, char* argv[]){
@@ -30,29 +31,30 @@ int main(int argc, char* argv[]){
   string prefix = "neut_1GeV_numu_NCQE_O_MDLQE422_NUCDEXITE0";
   if(argc==2) prefix = argv[1];
   int seed=1;
+  int verbose=2;
   //-----------------.//
 
   ostringstream os;
 
-  // --- prepare deex tools
+  // --- Setup routine --- //
+  NucDeEx::Utils::fVerbose=verbose; // optional (default: 0)
+  NucDeEx::Random::SetSeed(seed); // optional (default: 1)
+  NucDeExDeexcitation* deex = new NucDeExDeexcitation(2,1); // should be after seting verbosity
+  // --------------------- //
+
   int Zt=0, Nt=0;
   double S;
-  // Set params before declaring NucDeExDeexcitation
-  NucDeExUtils::SetVerbose(2);
-  NucDeExUtils::SetSeed(seed);
-  NucDeExDeexcitation* deex = new NucDeExDeexcitation(2, 1);
-  NucDeExNucleusTable* nucleus_table = deex->GetNucleusTablePtr();
   bool flag_O=0;
   if(prefix.find("_C_")!=string::npos){
     Zt=6;
     Nt=6;
     os << getenv("NUCDEEX_ROOT") << "/tables/sf/pke12_tot.root";
-    S = nucleus_table->GetNucleusPtr("12C")->S[2];
+    S = NucDeEx::Utils::NucleusTable->GetNucleusPtr("12C")->S[2];
   }else if(prefix.find("_O_")!=string::npos){
     Zt=8;
     Nt=8;
     os << getenv("NUCDEEX_ROOT") << "/tables/sf/pke16.root";
-    S = nucleus_table->GetNucleusPtr("16O")->S[2];
+    S = NucDeEx::Utils::NucleusTable->GetNucleusPtr("16O")->S[2];
     flag_O=1;
   }
   cout << "Separation E = " << S << endl;
@@ -199,18 +201,18 @@ int main(int argc, char* argv[]){
     //cout << MissE << "   "  << S <<  "  " << Ex << endl;
     h_Ex[0]->Fill(Ex);
 
-    // --- DOIT --- //
-    deex->DoDeex(Zt,Nt,Z,N,0,Ex,TVector3(0,0,0));
+    // --- DO SIMULATION --- //
+    NucDeExEventInfo result = deex->DoDeex(Zt,Nt,Z,N,0,Ex,TVector3(0,0,0));
 
     // --- Scoring --- //
-    int shell = deex->GetShell();
-    h_Ex[shell]->Fill(Ex);
-    vector<NucDeExParticle>* particle = deex->GetParticleVector();
-    int size=particle->size();
+    int shell = result.fShell;
+    vector<NucDeExParticle> particle = result.ParticleVector;
+    int size=particle.size();
     for(int i=0;i<size;i++){
-      NucDeExParticle p = particle->at(i);
+      NucDeExParticle p = particle.at(i);
       if(p._PDG==2112) nmulti++;
     }
+    h_Ex[shell]->Fill(Ex);
     h_nmulti_postdeex->Fill(nmulti);
   }
 

--- a/main/nuwro.cc
+++ b/main/nuwro.cc
@@ -14,6 +14,7 @@
 
 #include"event1.h"
 
+#include "NucDeExUtils.hh"
 #include "NucDeExNucleusTable.hh"
 #include "NucDeExDeexcitation.hh"
 
@@ -31,9 +32,10 @@ int main(int argc, char* argv[]){
   // --- prepare deex tools
   int Zt=0, Nt=0;
   double S;
+  // Set params before declaring NucDeExDeexcitation
+  NucDeExUtils::SetVerbose(2);
+  NucDeExUtils::SetSeed(seed);
   NucDeExDeexcitation* deex = new NucDeExDeexcitation(2, 1);
-  deex->SetSeed(seed);
-  deex->SetVerbose(1);
   NucDeExNucleusTable* nucleus_table = deex->GetNucleusTablePtr();
   bool flag_O=0;
   if(prefix.find("QE_C")!=string::npos){

--- a/main/nuwro.cc
+++ b/main/nuwro.cc
@@ -15,8 +15,9 @@
 #include"event1.h"
 
 #include "NucDeExUtils.hh"
-#include "NucDeExNucleusTable.hh"
+#include "NucDeExRandom.hh"
 #include "NucDeExDeexcitation.hh"
+#include "NucDeExEventInfo.hh"
 
 using namespace std;
 
@@ -25,29 +26,30 @@ int main(int argc, char* argv[]){
   string prefix = "SF_LFG_14_1000_CCQE_C";
   if(argc==2) prefix = argv[1];
   int seed=1;
+  int verbose=2;
   //-----------------.//
 
   ostringstream os;
 
-  // --- prepare deex tools
+  // --- Setup routine --- //
+  NucDeEx::Utils::fVerbose=verbose; // optional (default: 0)
+  NucDeEx::Random::SetSeed(seed); // optional (default: 1)
+  NucDeExDeexcitation* deex = new NucDeExDeexcitation(2,1); // should be after seting verbosity
+  // --------------------- //
+
   int Zt=0, Nt=0;
   double S;
-  // Set params before declaring NucDeExDeexcitation
-  NucDeExUtils::SetVerbose(2);
-  NucDeExUtils::SetSeed(seed);
-  NucDeExDeexcitation* deex = new NucDeExDeexcitation(2, 1);
-  NucDeExNucleusTable* nucleus_table = deex->GetNucleusTablePtr();
   bool flag_O=0;
   if(prefix.find("QE_C")!=string::npos){
     Zt=6;
     Nt=6;
     os << getenv("NUCDEEX_ROOT") << "/tabels/sf/pke12_tot.root";
-    S = nucleus_table->GetNucleusPtr("12C")->S[2];
+    S = NucDeEx::Utils::NucleusTable->GetNucleusPtr("12C")->S[2];
   }else if(prefix.find("QE_O")!=string::npos){
     Zt=8;
     Nt=8;
     os << getenv("NUCDEEX_ROOT") << "/tables/sf/pke16.root";
-    S = nucleus_table->GetNucleusPtr("16O")->S[2];
+    S = NucDeEx::Utils::NucleusTable->GetNucleusPtr("16O")->S[2];
     flag_O=1;
   }
   cout << "Separation E = " << S << endl;
@@ -116,18 +118,18 @@ int main(int argc, char* argv[]){
     }
     cout << endl;
 
-    // --- DOIT --- //
-    deex->DoDeex(Zt,Nt,event->pr,event->nr,0,Ex,TVector3(0,0,0));
+    // --- DO SIMULATION --- //
+    NucDeExEventInfo result = deex->DoDeex(Zt,Nt,event->pr,event->nr,0,Ex,TVector3(0,0,0));
 
     // --- Scoring --- //
-    int shell = deex->GetShell();
-    h_Ex[shell]->Fill(Ex);
-    vector<NucDeExParticle>* particle = deex->GetParticleVector();
-    int size=particle->size();
+    int shell = result.fShell;
+    vector<NucDeExParticle> particle = result.ParticleVector;
+    int size=particle.size();
     for(int i=0;i<size;i++){
-      NucDeExParticle p = particle->at(i);
+      NucDeExParticle p = particle.at(i);
       if(p._PDG==2112) nmulti++;
     }
+    h_Ex[shell]->Fill(Ex);
     h_nmulti_postdeex->Fill(nmulti);
   }
 

--- a/main/plot_decay.cc
+++ b/main/plot_decay.cc
@@ -5,6 +5,7 @@
 #include <iomanip> 
 
 #include "NucDeExConsts.hh"
+#include "NucDeExUtils.hh"
 #include "NucDeExNucleusTable.hh"
 #include "ReadTALYS.hh"
 
@@ -56,8 +57,8 @@ int main(int argc, char* argv[]){
   }
   os << "/output_" << argv[1] << "_ldmodel" << ldmodel;
   if(parity_optmodall) os << "_parity_optmodall";
+  NucDeExUtils::SetVerbose(1);
   ReadTALYS* read_talys = new ReadTALYS(os.str().c_str(), nucleus_table);
-  read_talys->SetVerboseLevel(1);
   if(!read_talys->Read()){
     std::cerr << "something wrong happend..." << std::endl;
     return 0;

--- a/main/plot_decay.cc
+++ b/main/plot_decay.cc
@@ -38,6 +38,7 @@ int main(int argc, char* argv[]){
   const bool flag_jpi = (bool) atoi(argv[4]);
   
   std::ostringstream os;
+  NucDeExUtils::SetVerbose(1);
   NucDeExNucleusTable* nucleus_table = new NucDeExNucleusTable();
   if(!nucleus_table->ReadTables()){
     std::cerr << "something wrong" << std::endl;
@@ -57,7 +58,6 @@ int main(int argc, char* argv[]){
   }
   os << "/output_" << argv[1] << "_ldmodel" << ldmodel;
   if(parity_optmodall) os << "_parity_optmodall";
-  NucDeExUtils::SetVerbose(1);
   ReadTALYS* read_talys = new ReadTALYS(os.str().c_str(), nucleus_table);
   if(!read_talys->Read()){
     std::cerr << "something wrong happend..." << std::endl;

--- a/main/plot_decay.cc
+++ b/main/plot_decay.cc
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]){
   const bool flag_jpi = (bool) atoi(argv[4]);
   
   std::ostringstream os;
-  NucDeExUtils::SetVerbose(1);
+  NucDeEx::Utils::fVerbose=1;
   NucDeExNucleusTable* nucleus_table = new NucDeExNucleusTable();
   if(!nucleus_table->ReadTables()){
     std::cerr << "something wrong" << std::endl;

--- a/main/simulation.cc
+++ b/main/simulation.cc
@@ -4,6 +4,7 @@
 #include <string>
 #include <iomanip> 
 
+#include "NucDeExUtils.hh"
 #include "NucDeExNucleusTable.hh"
 #include "NucDeExDeexcitation.hh"
 
@@ -21,15 +22,16 @@
 #include <THStack.h>
 
 int main(int argc, char* argv[]){
-  if(argc<5){
-    std::cerr << "Input: " << argv[0] << " [Target nucleus] [ldmodel] [parity&optmodall] [flag_jpi] [Random Seed (optional)]" << std::endl;
+  if(argc<=5){
+    std::cerr << "Input: " << argv[0] << " [Target nucleus] [ldmodel] [parity&optmodall] [flag_jpi] [verbosity] [Random Seed (optional)]" << std::endl;
     return 0;
   }
   const int ldmodel=atoi(argv[2]);
   const bool parity_optmodall=(bool)atoi(argv[3]);
   const bool flag_jpi = (bool) atoi(argv[4]);
+  const int verbose = atoi(argv[5]);
   int seed=1; // default: 1
-  if(argc==6) seed = atoi(argv[5]);
+  if(argc==7) seed = atoi(argv[6]);
   std::cout << "SEED = " << seed << std::endl;
 
   // ---- FIXME --- // 
@@ -45,10 +47,10 @@ int main(int argc, char* argv[]){
 
   std::ostringstream os,os_remove_g;
 
-  // Set deex tool
+  // Set params before declaring NucDeExDeexcitation
+  NucDeExUtils::SetVerbose(verbose);
+  NucDeExUtils::SetSeed(seed);
   NucDeExDeexcitation* deex = new NucDeExDeexcitation(ldmodel, parity_optmodall);
-  deex->SetSeed(seed); // 0: time
-  deex->SetVerbose(2);
   // Get Z and N
   NucDeExNucleusTable* nucleus_table = deex->GetNucleusTablePtr();
   NucDeExNucleus* nuc = nucleus_table->GetNucleusPtr(argv[1]);

--- a/main/simulation.cc
+++ b/main/simulation.cc
@@ -33,6 +33,8 @@ int main(int argc, char* argv[]){
   const int verbose = atoi(argv[5]);
   int seed=1; // default: 1
   if(argc==7) seed = atoi(argv[6]);
+
+  std::cout << "VERBOSE = " << verbose << std::endl;
   std::cout << "SEED = " << seed << std::endl;
 
   // ---- FIXME --- // 
@@ -50,9 +52,9 @@ int main(int argc, char* argv[]){
 
   // --- Setup routine --- //
   NucDeEx::Utils::fVerbose=verbose; // optional (default: 0)
-  NucDeEx::Random::SetSeed(seed); // optinal (default: 1)
+  NucDeEx::Random::SetSeed(seed); // optional (default: 1)
   NucDeExDeexcitation* deex = new NucDeExDeexcitation(ldmodel, parity_optmodall); // should be after seting verbosity
-  // --- End of rootine --- //
+  // --------------------- //
 
   // Get Z and N
   NucDeExNucleus* nuc = NucDeEx::Utils::NucleusTable->GetNucleusPtr(argv[1]);
@@ -63,7 +65,6 @@ int main(int argc, char* argv[]){
   if(Z+N==11) Zt=6,Nt=6;
   if(Z+N==15) Zt=8,Nt=8;
   
-
   // prepare output root file
   os.str("");  
   os << "sim_out/";

--- a/main/simulation.cc
+++ b/main/simulation.cc
@@ -4,11 +4,6 @@
 #include <string>
 #include <iomanip> 
 
-#include "NucDeExUtils.hh"
-#include "NucDeExRandom.hh"
-#include "NucDeExDeexcitation.hh"
-#include "NucDeExEventInfo.hh"
-
 #include <TROOT.h>
 #include <TStyle.h>
 #include <TFile.h>
@@ -21,6 +16,11 @@
 #include <TText.h>
 #include <TPaveText.h>
 #include <THStack.h>
+
+#include "NucDeExUtils.hh"
+#include "NucDeExRandom.hh"
+#include "NucDeExDeexcitation.hh"
+#include "NucDeExEventInfo.hh"
 
 int main(int argc, char* argv[]){
   if(argc<=5){

--- a/main/simulation.cc
+++ b/main/simulation.cc
@@ -5,8 +5,9 @@
 #include <iomanip> 
 
 #include "NucDeExUtils.hh"
-#include "NucDeExNucleusTable.hh"
+#include "NucDeExRandom.hh"
 #include "NucDeExDeexcitation.hh"
+#include "NucDeExEventInfo.hh"
 
 #include <TROOT.h>
 #include <TStyle.h>
@@ -47,13 +48,14 @@ int main(int argc, char* argv[]){
 
   std::ostringstream os,os_remove_g;
 
-  // Set params before declaring NucDeExDeexcitation
-  NucDeExUtils::SetVerbose(verbose);
-  NucDeExUtils::SetSeed(seed);
-  NucDeExDeexcitation* deex = new NucDeExDeexcitation(ldmodel, parity_optmodall);
+  // --- Setup routine --- //
+  NucDeEx::Utils::fVerbose=verbose; // optional (default: 0)
+  NucDeEx::Random::SetSeed(seed); // optinal (default: 1)
+  NucDeExDeexcitation* deex = new NucDeExDeexcitation(ldmodel, parity_optmodall); // should be after seting verbosity
+  // --- End of rootine --- //
+
   // Get Z and N
-  NucDeExNucleusTable* nucleus_table = deex->GetNucleusTablePtr();
-  NucDeExNucleus* nuc = nucleus_table->GetNucleusPtr(argv[1]);
+  NucDeExNucleus* nuc = NucDeEx::Utils::NucleusTable->GetNucleusPtr(argv[1]);
   const int Z = nuc->Z;
   const int N = nuc->N;
   const int A = Z+N;
@@ -131,10 +133,10 @@ int main(int argc, char* argv[]){
   if(flag_jpi){
     if(Z+N==11){ // 12C
       os << getenv("NUCDEEX_ROOT") << "/tables/sf/pke12_tot.root";
-      S = nucleus_table->GetNucleusPtr("12C")->S[2];
+      S = NucDeEx::Utils::NucleusTable->GetNucleusPtr("12C")->S[2];
     }else if(Z+N==15){
       os << getenv("NUCDEEX_ROOT") << "/tables/sf/pke16.root";
-      S = nucleus_table->GetNucleusPtr("16O")->S[2];
+      S = NucDeEx::Utils::NucleusTable->GetNucleusPtr("16O")->S[2];
     }
   }else{
     std::cerr << "flag_jpi = " << flag_jpi << std::endl;
@@ -193,19 +195,21 @@ int main(int argc, char* argv[]){
     if(Ex_min>0 && Ex<Ex_min) continue;
     if(Ex_max>0 && Ex>Ex_max) continue;
 
-    // DOIT 
-    //deex->DoDeex(Zt,Nt,Z,N,1,Ex,Pinit); // s1/2-hole 
-    //deex->DoDeex(Zt,Nt,Z,N,2,Ex,Pinit); // p3/2-hole
-    //deex->DoDeex(Zt,Nt,Z,N,3,Ex,Pinit); // p1/2-hole (nothing to do)
-    deex->DoDeex(Zt,Nt,Z,N,0,Ex,Pinit); // shell level is determined from Ex (box cut)
+    // --- DO SIMULATION --- //
+    NucDeExEventInfo result = deex->DoDeex(Zt,Nt,Z,N,0,Ex,Pinit); // shell level is determined from Ex (box cut)
+      // 5th index
+      //    1: s1/2-hole
+      //    2: p3/2-hole
+      //    3: p1/2-hole (nothing to do. g.s.)
 
-    // scoling
-    shell = deex->GetShell();
-    vector<NucDeExParticle>* particle = deex->GetParticleVector();
+
+    // --- Scoling --- //
+    shell = result.fShell;
+    vector<NucDeExParticle> particle = result.ParticleVector;
     PinitX   = Pinit.X();
     PinitY   = Pinit.Y();
     PinitZ   = Pinit.Z();
-    size=particle->size();
+    size=particle.size();
 
     h_sf_Ex_random[shell]->Fill(Ex);
     
@@ -213,7 +217,7 @@ int main(int argc, char* argv[]){
     os_remove_g.str("");
     string pname[size];
     for(int i=0;i<size;i++){
-      NucDeExParticle p = particle->at(i);
+      NucDeExParticle p = particle.at(i);
       PDG[i]=p._PDG;
       mass[i]=p._mass;
       totalE[i]=p.totalE();

--- a/src/G4INCLNucDeExInterface.cc
+++ b/src/G4INCLNucDeExInterface.cc
@@ -3,6 +3,7 @@
 #include "G4INCLParticle.hh"
 #include "G4INCLGlobals.hh"
 #include "G4INCLParticleSpecies.hh"
+#include "NucDeExUtils.hh"
 #include <iostream>
 
 G4INCLNucDeExInterface::G4INCLNucDeExInterface(G4INCL::Config *config) :
@@ -10,8 +11,8 @@ G4INCLNucDeExInterface::G4INCLNucDeExInterface(G4INCL::Config *config) :
   theConfig(config),
   theNucDeEx(new NucDeExDeexcitation(2,1,theConfig))
 {
-  theNucDeEx->SetSeed(1);
-  theNucDeEx->SetVerbose(0);
+  NucDeExUtils::SetSeed(1);
+  NucDeExUtils::SetVerbose(1);
   Zt = theConfig->getTargetZ();
   At = theConfig->getTargetA();
   Nt = At-Zt;

--- a/src/G4NucDeExInterface.cc
+++ b/src/G4NucDeExInterface.cc
@@ -31,6 +31,8 @@
 
 #ifdef NUCDEEX_IN_GEANT4_MODE
 
+#include "NucDeExUtils.hh"
+
 #include "G4NucDeExInterface.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4ReactionProductVector.hh"
@@ -48,9 +50,9 @@ G4NucDeExInterface::G4NucDeExInterface() :
   theG4PreCompound(new G4PreCompoundModel),
   eventNumber(0)
 {
-  verbose=0;
-  theNucDeEx->SetSeed(1);
-  theNucDeEx->SetVerbose(verbose);
+  NucDeExUtils::SetPATH();
+  NucDeExUtils::SetSeed(1);
+  NucDeExUtils::SetVerbose(1);
   // This is tentavie solution. We cannot get parent nucleus informationi
   Zt=8, Nt=8, At=16; // FIXME
 }
@@ -61,10 +63,10 @@ G4NucDeExInterface::G4NucDeExInterface(G4VPreCompoundModel* preco) :
   eventNumber(0)
 {
   G4cout << "NucDeEx: Get G4PreCompoundModel by using G4HadronicInteractionRegistry" << G4endl;
-  verbose=0;
   theG4PreCompound = preco;
-  theNucDeEx->SetSeed(1);
-  theNucDeEx->SetVerbose(verbose);
+  NucDeExUtils::SetPATH();
+  NucDeExUtils::SetSeed(1);
+  NucDeExUtils::SetVerbose(1);
   // This is tentavie solution. We cannot get parent nucleus informationi
   Zt=8, Nt=8, At=16; // FIXME
 }
@@ -86,13 +88,13 @@ G4ReactionProductVector *G4NucDeExInterface::DeExcite(G4Fragment &aFragment) {
   Pinit.SetXYZ(pxRem,pyRem,pzRem);
 
   eventNumber++;
-  if(verbose>1) G4cout << "NucDeEx: ZRem = " << ZRem << "  ARem = " << ARem << "   eStarRem = " << eStarRem << G4endl;
+  if(NucDeExUtils::GetVerbose()>1) G4cout << "NucDeEx: ZRem = " << ZRem << "  ARem = " << ARem << "   eStarRem = " << eStarRem << G4endl;
   int status = theNucDeEx->DoDeex(Zt,Nt,
                                   ZRem,ARem-ZRem,
                                   0,eStarRem,Pinit);
   G4ReactionProductVector *result;
   if(status!=1){// NucDeEx status is bad -> use G4PreCompoundModel
-    if(verbose>0) G4cout << "Use G4PreCompoundModel instead of NucDeEx" << G4endl;
+    if(NucDeExUtils::GetVerbose()>0) G4cout << "Use G4PreCompoundModel instead of NucDeEx" << G4endl;
     result = theG4PreCompound->DeExcite(aFragment);
   }else{ // NucDeEx status is good -> use it!
     result = new G4ReactionProductVector;
@@ -116,7 +118,7 @@ G4ReactionProductVector *G4NucDeExInterface::DeExcite(G4Fragment &aFragment) {
         A = (PDG%10000)/10;
         Z = (PDG%10000000-A*10)/10000;
       }
-      if(verbose>1) G4cout << "NucDeEx: PDG = " << PDG << "  kE = " << particle.kE() << G4endl;
+      if(NucDeExUtils::GetVerbose()>1) G4cout << "NucDeEx: PDG = " << PDG << "  kE = " << particle.kE() << G4endl;
 
       G4ReactionProduct *product = toG4Particle(A,Z,0, // S
                                                 particle.kE(),
@@ -170,7 +172,7 @@ G4ReactionProduct *G4NucDeExInterface::toG4Particle(G4int A, G4int Z, G4int S,
 }
 
 void G4NucDeExInterface::ModelDescription(std::ostream& outFile) const {
-   outFile << "NUCDEEX++ does not provide an implementation of the ApplyYourself method!\n\n";
+   outFile << "NUCDEEX does not provide an implementation of the ApplyYourself method!\n\n";
 }
 
 void G4NucDeExInterface::DeExciteModelDescription(std::ostream& outFile) const {

--- a/src/G4NucDeExInterface.cc
+++ b/src/G4NucDeExInterface.cc
@@ -50,7 +50,6 @@ G4NucDeExInterface::G4NucDeExInterface() :
   theG4PreCompound(new G4PreCompoundModel),
   eventNumber(0)
 {
-  NucDeExUtils::SetPATH();
   NucDeExUtils::SetSeed(1);
   NucDeExUtils::SetVerbose(1);
   // This is tentavie solution. We cannot get parent nucleus informationi
@@ -64,7 +63,6 @@ G4NucDeExInterface::G4NucDeExInterface(G4VPreCompoundModel* preco) :
 {
   G4cout << "NucDeEx: Get G4PreCompoundModel by using G4HadronicInteractionRegistry" << G4endl;
   theG4PreCompound = preco;
-  NucDeExUtils::SetPATH();
   NucDeExUtils::SetSeed(1);
   NucDeExUtils::SetVerbose(1);
   // This is tentavie solution. We cannot get parent nucleus informationi

--- a/src/NEUTNucDeExInterace.cc
+++ b/src/NEUTNucDeExInterace.cc
@@ -3,6 +3,8 @@
 #include "vcworkC.h"
 #include "posinnucC.h"
 #include "vcvrtxC.h"
+
+#include "NucDeExUtils.hh"
 #include "NucDeExDeexcitation.hh"
 
 NucDeExDeexcitation* nucdeex;
@@ -17,7 +19,7 @@ extern "C"{
 
 ///////////////////////////
 int nucdeex_()
-///////////////////////////
+t ///////////////////////////
 {
   //std::cout << vcwork_.ipvc[1] << "   " << posinnuc_.ibound << std::endl;
   if(vcwork_.ipvc[1]!=2112 && vcwork_.ipvc[1]!=2212) return 0;
@@ -108,8 +110,8 @@ void NucDeExInitialize(void)
   if(!nucdeex_initialized){
     std::cout << "NucDeEx initialized" << std::endl;
     nucdeex = new NucDeExDeexcitation(2,1);
-    nucdeex->SetSeed(1); // 0: time
-    nucdeex->SetVerbose(0);  
+    NucDeExUtils::SetSeed(1);
+    NucDeExUtils::SetVerbose(1);
   }
   nucdeex_initialized=true;
   return;

--- a/src/NucDeExDeexcitation.cc
+++ b/src/NucDeExDeexcitation.cc
@@ -23,10 +23,10 @@ NucDeExDeexcitation::NucDeExDeexcitation(const int ld, const bool p_o)
   ldmodel=ld;
   parity_optmodall=p_o;
   NucDeEx::Utils::SetPATH();
+  NucDeEx::Utils::NucleusTable->ReadTables(0); // should be after SetPATH
   deex_talys = new NucDeExDeexcitationTALYS(ldmodel,parity_optmodall);
   deex_phole = new NucDeExDeexcitationPhole();
   deex_phole->SetPtrTALYS(deex_talys);
-  Init();
 }
 
 #ifdef INCL_DEEXCITATION_NUCDEEX
@@ -37,10 +37,10 @@ NucDeExDeexcitation::NucDeExDeexcitation(const int ld, const bool p_o, G4INCL::C
   ldmodel=ld;
   parity_optmodall=p_o;
   NucDeEx::Utils::SetPATH(config);
+  NucDeEx::Utils::NucleusTable->ReadTables(0); // should be after SetPATH
   deex_talys = new NucDeExDeexcitationTALYS(ldmodel,parity_optmodall);
   deex_phole = new NucDeExDeexcitationPhole();
   deex_phole->SetPtrTALYS(deex_talys);
-  Init();
 }
 #endif
 

--- a/src/NucDeExDeexcitation.cc
+++ b/src/NucDeExDeexcitation.cc
@@ -75,10 +75,7 @@ NucDeExEventInfo NucDeExDeexcitation::DoDeex(const int Zt, const int Nt,
   SaveEventLevelInfo(Zt,Nt,Z,N,Ex,mom);
 
   // --- Call sub functions according to shell and nucleus conditions- --//
-  if(Ex<=0){
-    AddGSNucleus(Z,N,mom);
-    fShell=3;
-  }else if( (Zt==Z && Nt==N+1) || (Zt==Z+1 && Nt==N) ){
+  if( (Zt==Z && Nt==N+1) || (Zt==Z+1 && Nt==N) ){
     // --- Single nucleon disapperance
     // determine shell level of hole
     if(shell>0) fShell=shell;

--- a/src/NucDeExDeexcitation.cc
+++ b/src/NucDeExDeexcitation.cc
@@ -10,11 +10,16 @@
 #include <vector>
 
 #include "NucDeExUtils.hh"
+#include "NucDeExRandom.hh"
 #include "NucDeExDeexcitation.hh"
 
 #include <TGraph.h>
 #include <TParticlePDG.h>
 #include <TParticle.h>
+
+///////////////////////////
+NucDeExDeexcitation::NucDeExDeexcitation():ldmodel(2),parity_optmodall(1){};
+///////////////////////////
 
 ///////////////////////////
 NucDeExDeexcitation::NucDeExDeexcitation(const int ld, const bool p_o)
@@ -23,7 +28,9 @@ NucDeExDeexcitation::NucDeExDeexcitation(const int ld, const bool p_o)
   ldmodel=ld;
   parity_optmodall=p_o;
   NucDeEx::Utils::SetPATH();
-  _nucleus_table = new NucDeExNucleusTable();
+  deex_talys = new NucDeExDeexcitationTALYS(ldmodel,parity_optmodall);
+  deex_phole = new NucDeExDeexcitationPhole();
+  deex_phole->SetPtrTALYS(deex_talys);
   Init();
 }
 
@@ -35,41 +42,23 @@ NucDeExDeexcitation::NucDeExDeexcitation(const int ld, const bool p_o, G4INCL::C
   ldmodel=ld;
   parity_optmodall=p_o;
   NucDeEx::Utils::SetPATH(config);
+  deex_talys = new NucDeExDeexcitationTALYS(ldmodel,parity_optmodall);
+  deex_phole = new NucDeExDeexcitationPhole();
+  deex_phole->SetPtrTALYS(deex_talys);
   Init();
 }
 #endif
 
 ///////////////////////////
-void NucDeExDeexcitation::Init()
-///////////////////////////
-{
-  _nucleus_table = new NucDeExNucleusTable();
-  if(!_nucleus_table->ReadTables(0)){
-    std::cerr << "Fatal Error" << std::endl;
-    abort();
-  }
-  pdg = new TDatabasePDG();
-  geo = new TGeoManager("NucDeEx","NucDeEx");
-  element_table = geo->GetElementTable();
-  eventID=0;
-  for(int p=0;p<NucDeEx::num_particle;p++){
-    g_br[p]=0;
-  }
-  g_br_ex=0;
-}
-
-
-///////////////////////////
 NucDeExDeexcitation::~NucDeExDeexcitation()
 ///////////////////////////
 {
-  delete _nucleus_table;
-  delete pdg;
-  delete geo;
+  delete deex_talys;
+  delete deex_phole;
 }
 
 /////////////////////////////////////////////
-const NucDeExEventInfo NucDeExDeexcitation::DoDeex(const int Zt, const int Nt,
+NucDeExEventInfo NucDeExDeexcitation::DoDeex(const int Zt, const int Nt,
                           const int Z, const int N, const int shell, const double Ex, const TVector3& mom)
 /////////////////////////////////////////////
 {
@@ -80,393 +69,52 @@ const NucDeExEventInfo NucDeExDeexcitation::DoDeex(const int Zt, const int Nt,
   if(NucDeEx::Utils::fVerbose>0){
     std::cout << std::endl << "###################################" << std::endl;
     std::cout << "NucDeExDeexcitation::DoDeex(" << Zt << "," << Nt<< ","  << Z << "," << N 
-         << "," << shell << "," << Ex << ")  eventID=" << eventID << std::endl;
+         << "," << shell << "," << Ex << ")  EventID=" << EventID << std::endl;
     std::cout << "###################################" << std::endl;
   }
+  
 
-  // -- init --- //
+  // --- Save event level info (except for shell & status) --- //
   EventInfo.InitParameters();
-  int status=-1;
+  SaveEventLevelInfo(Zt,Nt,Z,N,Ex,mom);
 
   // --- Call sub functions according to shell and nucleus conditions- --//
-  if(Ex<=0){ // --- negative Ex
-    status=AddGSNucleus(Z,N,mom);
-  }else if(Zt+Nt == Z+N){ // --- No change in Atomic number (Coherent scattering etc.)
-    status=DoDeex_talys(Zt,Nt,Z,N,Ex,mom);
-  }else if( (Zt==Z && Nt==N+1) || (Zt==Z+1 && Nt==N) ){ // --- Single nucleon disapperance
+  if(Ex<=0){
+    AddGSNucleus(Z,N,mom);
+  }else if( (Zt==Z && Nt==N+1) || (Zt==Z+1 && Nt==N) ){
+    // --- Single nucleon disapperance
     // determine shell level of hole
-    if(shell>0) _shell=shell;
-    else if(shell==0) _shell=ExtoShell(Zt,Nt,Ex);
-    else abort();
+    if(shell>0) fShell=shell;
+    else if(shell==0) fShell=ExtoShell(Zt,Nt,Ex);
+    else exit(1);
     //
-    if(_shell==3){ 
-      // p1/2-hole. nothing to do
-      if(NucDeEx::Utils::fVerbose>0) std::cout << "(p1/2)-hole" <<std::endl;
-      status=AddGSNucleus(Z,N,mom);
-    }else if(_shell==2){
-      // p3/2-hole 
-      status=DoDeex_p32(Zt,Nt,Z,N,mom); 
-    }else if(_shell==1){
-      // s1/2-hole read TALYS data
-      status=DoDeex_talys(Zt,Nt,Z,N,Ex,mom);
-    }else{ // bug case
-      std::cerr << "ERROR: Unexpected shell level: shell = " << _shell << std::endl;
-      abort();
+    if(fShell==3){ // p1/2-hole. nothing to do
+      if(NucDeEx::Utils::fVerbose>0) std::cout << "(p1/2)-hole -> g.s." <<std::endl;
+      AddGSNucleus(Z,N,mom);
+    }else if(fShell==2){ // p3/2-hole 
+      EventInfo = deex_phole->DoDeex(Zt,Nt,Z,N,Ex,mom); 
+    }else if(fShell==1){// s1/2-hole read TALYS data
+      EventInfo = deex_talys->DoDeex(Zt,Nt,Z,N,Ex,mom);
+    }else{
+      std::cerr << "ERROR: Unexpected shell level: shell = " << fShell << std::endl;
+      exit(1);
     }
-  }else if(Zt+Nt>Z+N){ // --- Multi-nucleon disapperance
-    status=DoDeex_talys(Zt,Nt,Z,N,Ex,mom);
-  }else{ // Zt and Nt are larger than Z and N. This can be happen in the use in Geant4
+  }else if( (Zt+Nt>Z+N) || (Zt+Nt == Z+N) ){
+    // multi nucleon disapperanace or no change in Atomic number (Coherent scattering etc.)
+    EventInfo = deex_talys->DoDeex(Zt,Nt,Z,N,Ex,mom);
+  }else{ // Zt and Nt are larger than Z and N. This can be happen in the use in Geant4. Do nothing.
     if(NucDeEx::Utils::fVerbose>0){
       std::cerr << "Waring: Unexpected target & residual nuclei: "
                 << "Zt = " << Zt << "   Nt = " << Nt << "  Z = " << Z << "   N = " << N << std::endl;
     }
-    status=-1;
+    EventInfo.fStatus=0;
   }
 
   // event level info
-  EventInfo.eventID = eventID;
-  EventInfo.fStatus = status;
-  EventInfo.fShell = _shell;
-  EventInfo.Zt     = Zt;
-  EventInfo.Nt     = Nt;
-  EventInfo.Z      = Z;
-  EventInfo.N      = N;
-  EventInfo.Ex     = Ex;
-  EventInfo.Pinit  = mom;
+  EventInfo.fShell = fShell;
 
-  eventID++;
+  EventID++;
   return EventInfo;
-}
-
-/////////////////////////////////////////////
-int NucDeExDeexcitation::DoDeex_talys(const int Zt, const int Nt,
-                               const int Z, const int N, const double Ex, const TVector3& mom)
-/////////////////////////////////////////////
-{
-  if(NucDeEx::Utils::fVerbose>0) std::cout << "DoDeex_talys()" << std::endl;
-  RESET:
-  int status=1; // success
-
-
-  // store target info. we don't want to change original value.
-  Z_target   = Z;
-  N_target   = N;
-  Ex_target  = Ex;
-  mom_target = mom;
-  nuc_target = _nucleus_table->GetNucleusPtr(Z_target,N_target);
-  if(nuc_target==NULL){
-    if(NucDeEx::Utils::fVerbose>0){
-      std::cout << "We don't have deexcitation profile for this nucleus: "
-           << name_target.c_str() << std::endl;
-    }
-    //AddGSNucleus(Z,N,mom); // nothing can be done for this case...(no mass profile)
-    status=-1;
-    return status;
-  }
-  name_target = (string)nuc_target->name;
-
-  // Read ROOT file
-  if( ! OpenROOT(Zt,Nt,Z,N) ){
-    if(NucDeEx::Utils::fVerbose>0){
-      std::cout << "We don't have deexcitation profile for this nucleus: " 
-           << name_target.c_str() << std::endl;
-    }
-    AddGSNucleus(Z,N,mom);
-    status=0;
-    return status;
-  }
-  
-  // Loop until zero excitation energy or null nuc_daughter ptr
-  // Use private members (parameters) named as "_target"
-  while(true){// <- infinite loop. There is break point
-    if(NucDeEx::Utils::fVerbose>0){
-      std::cout << "### " << name_target << ",   Ex = " << Ex_target;
-      std::cout << "     mom_target: "; mom_target.Print();
-    }
-
-    // --- Get (TGraph*) br based on name_target
-    if(GetBrTGraph(name_target)){ // TGraph found
-      // --- Determine decay mode 
-      //     Return: The same as array in consts.hh
-      //     It also sets Z_daughter, Z_daughter
-      decay_mode = DecayMode(Ex_target); 
-
-      // --- Get nearest Ex bin (TGraph point) and then get (TGraph*) br_ex
-      if(GetBrExTGraph(name_target, Ex_target, decay_mode)==0){ // g.s.
-        AddGSNucleus(Z,N,mom);
-        status=1;
-        return status;
-      }
-
-      // --- Determine daughter excitation energy
-      int Ex_daughter_point;
-      DaughterExPoint(&Ex_daughter,&Ex_daughter_point);
-
-      // --- Get mass using ROOT libraries
-      if(decay_mode<=2){ // obtained from TDatabasePDG
-        mass_particle = pdg->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
-      }else{ // obtained from TGeoElementRN
-        int a_particle = (NucDeEx::PDG_particle[decay_mode]%1000)/10;
-        int z_particle = ((NucDeEx::PDG_particle[decay_mode]%1000000)-a_particle*10)/10000;
-        TGeoElementRN* element_rn =  element_table->GetElementRN(a_particle,z_particle); // (A,Z)
-        if(NucDeEx::Utils::fVerbose>1) std::cout << "a_particle = " << a_particle << "   z_particle = " << z_particle << std::endl;
-        mass_particle = ElementMassInMeV(element_rn);
-      }
-      // this rarely happens...
-      if(element_table->GetElementRN(Z_daughter+N_daughter,Z_daughter) == NULL){
-        if(NucDeEx::Utils::fVerbose>0){
-          std::cout << "Cannot find " << name_daughter << " in TGeoElementRN" << std::endl;
-          std::cout << "Call DoDeex() again!" << std::endl;
-        }
-        goto RESET; // call this fuc again
-      }
-      mass_target = ElementMassInMeV(element_table->GetElementRN(Z_target+N_target, Z_target));
-      mass_daughter = ElementMassInMeV(element_table->GetElementRN(Z_daughter+N_daughter, Z_daughter));
-    }else{ // no tgraph found -> gamma emission to g.s.
-      if(NucDeEx::Utils::fVerbose>0){
-        std::cout << "Cannot find TGraph" << std::endl;
-        std::cout << "Force gamma decay" << std::endl;
-      }
-      decay_mode=0; 
-      Ex_daughter=0;
-      mass_particle=0;
-      mass_daughter=mass_target;
-      status=0;
-    }
-
-    // --- Get separation E and Qvalue 
-    S = nuc_target->S[decay_mode];
-    Qvalue = Ex_target - S - Ex_daughter;
-    if(Qvalue<0) Qvalue=0;
-    if(NucDeEx::Utils::fVerbose>1){
-      std::cout << "S = " << S << std::endl;
-      std::cout << "Qvalue = " << Qvalue << std::endl;
-    }
-
-    bool breakflag=0;
-    if(nuc_daughter==NULL || Ex_daughter==0) breakflag=1;
-    
-    // --- Calculate kinematics --- //
-    if(Decay(breakflag)==0) status=0; // if breakflag==0, it does not save daughter nucleus
-
-    if(breakflag) break;
-
-    // end of while loop: daughter -> target 
-    Z_target  = Z_daughter;
-    N_target  = N_daughter;
-    Ex_target = Ex_daughter;
-    mass_target = mass_daughter;
-    mom_target  += mom_daughter;
-    nuc_target = nuc_daughter;
-    name_target = (string)nuc_target->name;
-    if(NucDeEx::Utils::fVerbose>0) std::cout << std::endl;
-
-    // --- Need this to release memory of TGraph
-    //    TGraph memory looks not relased only by closing & deleting root file...
-    DeleteTGraphs();
-  }
-
-  rootf->Close();
-  delete rootf;
-
-  return status;
-}
-
-/////////////////////////////////////////////
-int NucDeExDeexcitation::DoDeex_p32(const int Zt, const int Nt,
-                             const int Z, const int N, const TVector3& mom)
-/////////////////////////////////////////////
-{
-
-  // store target info. we don't want to change original value.
-  Z_target   = Z;
-  N_target   = N;
-  mom_target = mom;
-  nuc_target = _nucleus_table->GetNucleusPtr(Z_target,N_target);
-  name_target = (string)nuc_target->name;
-  if(NucDeEx::Utils::fVerbose>0){
-    std::cout << "DoDeex_p32()" << std::endl;
-    std::cout << "### " << name_target;
-    std::cout << "     mom_target: "; mom_target.Print();
-  }
-
-  double random = NucDeEx::Random::random();
-
-  //-----------11B------------//
-  if(Z==5 && N==6){
-  //--------------------------//
-    int index=0;
-    double Br_integ=0;
-    for(int i=0;i<Nlevel_p32_11B;i++){
-      Br_integ += Br_p32_11B[i];
-      if(random<Br_integ){
-        index=i;
-        break;
-      }
-    }
-    if(index==0){ // g.s.
-      AddGSNucleus(Z,N,mom);
-    }else{ // excited state
-      // set paremeters for boost calculation
-      decay_mode=0; 
-      Ex_target  = E_p32_11B[index];
-      Ex_daughter=0;
-      mass_particle=0;
-      mass_target = ElementMassInMeV(element_table->GetElementRN(Z_target+N_target, Z_target));
-      mass_daughter=mass_target;
-      name_daughter = name_target;
-      Z_daughter = Z_target;
-      N_daughter = N_target;
-      nuc_daughter = nuc_target;
-      S = nuc_target->S[decay_mode];
-      Qvalue = Ex_target - S - Ex_daughter;
-      Decay(1); // breakflag on
-    }
-  //-----------11C------------//
-  }else if(Z==6 && N==5){
-  //--------------------------//
-    int index=0;
-    double Br_integ=0;
-    for(int i=0;i<Nlevel_p32_11C;i++){
-      Br_integ += Br_p32_11C[i];
-      if(random<Br_integ){
-        index=i;
-        break;
-      }
-    }
-    if(index==0){ // g.s.
-      AddGSNucleus(Z,N,mom);
-    }else{ // excited state
-      // set paremeters for boost calculation
-      decay_mode=0; 
-      Ex_target  = E_p32_11C[index];
-      Ex_daughter=0;
-      mass_particle=0;
-      mass_target = ElementMassInMeV(element_table->GetElementRN(Z_target+N_target, Z_target));
-      mass_daughter=mass_target;
-      name_daughter = name_target;
-      Z_daughter = Z_target;
-      N_daughter = N_target;
-      nuc_daughter = nuc_target;
-      S = nuc_target->S[decay_mode];
-      Qvalue = Ex_target - S - Ex_daughter;
-      Decay(1); // breakflag on
-    }
-  //-----------15N------------//
-  }else if(Z==7 && N==8){
-  //--------------------------//
-    int index=0;
-    double Br_integ=0;
-    for(int i=0;i<Nlevel_p32_15N;i++){
-      Br_integ += Br_p32_15N[i];
-      if(random<Br_integ){
-        index=i;
-        break;
-      }
-    }
-    if(index==0){ // gamma
-      // set paremeters for boost calculation
-      decay_mode=0; 
-      Ex_target  = E_p32_15N[index];
-      Ex_daughter=0;
-      mass_particle=0;
-      mass_target = ElementMassInMeV(element_table->GetElementRN(Z_target+N_target, Z_target));
-      mass_daughter=mass_target;
-      name_daughter = name_target;
-      Z_daughter = Z_target;
-      N_daughter = N_target;
-      nuc_daughter = nuc_target;
-      S = nuc_target->S[decay_mode];
-      Qvalue = Ex_target - S - Ex_daughter;
-      Decay(1); // breakflag on
-    }else if(index==1){ // gamma but multiple -> read talys
-      DoDeex_talys(Zt,Nt,Z,N,E_p32_15N[index],mom);
-    }else if(index==2){
-      // set paremeters for boost calculation
-      decay_mode=2; // proton
-      Ex_target  = E_p32_15N[index];
-      Ex_daughter=0;
-      mass_particle = pdg->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
-      mass_target = ElementMassInMeV(element_table->GetElementRN(Z_target+N_target, Z_target));
-      Z_daughter = Z_target-1;
-      N_daughter = N_target;
-      mass_daughter = ElementMassInMeV(element_table->GetElementRN(Z_daughter+N_daughter, Z_daughter));
-      nuc_daughter = _nucleus_table->GetNucleusPtr(Z_daughter,N_daughter);
-      name_daughter = nuc_daughter->name;
-      S = nuc_target->S[decay_mode];
-      Qvalue = Ex_target - S - Ex_daughter;
-      Decay(1); // breakflag on
-    }else{
-      abort();
-    // return -1;
-    }
-  //-----------15O------------//
-  }else if(Z==8 && N==7){
-  //--------------------------//
-    int index=0;
-    double Br_integ=0;
-    for(int i=0;i<Nlevel_p32_15O;i++){
-      Br_integ += Br_p32_15O[i];
-      if(random<Br_integ){
-        index=i;
-        break;
-      }
-    }
-    if(index==0){ // gamma
-      // set paremeters for boost calculation
-      decay_mode=0; 
-      Ex_target  = E_p32_15O[index];
-      Ex_daughter=0;
-      mass_particle=0;
-      mass_target = ElementMassInMeV(element_table->GetElementRN(Z_target+N_target, Z_target));
-      mass_daughter=mass_target;
-      name_daughter = name_target;
-      Z_daughter = Z_target;
-      N_daughter = N_target;
-      S = nuc_target->S[decay_mode];
-      Qvalue = Ex_target - S - Ex_daughter;
-      Decay(1); // breakflag on
-    }else if(index==1||index==2){
-      // set paremeters for boost calculation
-      decay_mode=2; // proton
-      Ex_target  = E_p32_15O[index];
-      Ex_daughter=0;
-      mass_particle = pdg->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
-      mass_target = ElementMassInMeV(element_table->GetElementRN(Z_target+N_target, Z_target));
-      Z_daughter = Z_target-1;
-      N_daughter = N_target;
-      mass_daughter = ElementMassInMeV(element_table->GetElementRN(Z_daughter+N_daughter, Z_daughter));
-      nuc_daughter = _nucleus_table->GetNucleusPtr(Z_daughter,N_daughter);
-      name_daughter = nuc_daughter->name;
-      S = nuc_target->S[decay_mode];
-      Qvalue = Ex_target - S - Ex_daughter;
-      Decay(1); // breakflag on
-    }
-  }else{ 
-    abort();
-    // return -1;
-  }
-  return 1;
-}
-
-/////////////////////////////////////////////
-int NucDeExDeexcitation::AddGSNucleus(const int Z,const int N, const TVector3& mom)
-/////////////////////////////////////////////
-{
-  mass_target = ElementMassInMeV(element_table->GetElementRN(Z+N, Z));
-  nuc_target = _nucleus_table->GetNucleusPtr(Z,N);
-  if(nuc_target==NULL || mass_target<0) return -1; // do nothing
-  name_target = (string)nuc_target->name;
-  NucDeExParticle nucleus(PDGion(Z,N),
-                          mass_target, // w/o excitation E
-                          mom,
-                          name_target, 
-                          1,0); // track flag on // zero ex
-  EventInfo.ParticleVector->push_back(nucleus);
-  if(NucDeEx::Utils::fVerbose>0){
-    std::cout << "AddGSNucleus(): " << name_target << std::endl;
-  }
-  return 1;
 }
 
 
@@ -485,339 +133,3 @@ int NucDeExDeexcitation::ExtoShell(const int Zt, const int Nt, const double Ex)
   return -1;
 }
 
-/////////////////////////////////////////////
-int NucDeExDeexcitation::DecayMode(const double Ex)
-/////////////////////////////////////////////
-{
-  // --- Determine decay mode 
-  // ---- Return: (int)decay_mode_r 
-
-  double Br[NucDeEx::num_particle]={0};
-  double Br_sum=0;
-  for(int p=0;p<NucDeEx::num_particle;p++){
-    Br[p] = g_br[p]->Eval(Ex);
-    if(Br[p]<0) Br[p]=0;
-    Br_sum += Br[p];
-    if(NucDeEx::Utils::fVerbose>1){
-      std::cout << "Br(" << NucDeEx::particle_name[p].substr(0,1) << ") = " << Br[p] << std::endl;
-    }
-  }
-
-  double Br_integ=0;
-  double random = NucDeEx::Random::random();
-  int decay_mode_r=-1;
-  for(int p=0;p<NucDeEx::num_particle;p++){
-    Br[p] /= Br_sum; // Normalize Br just in case.  
-    Br_integ += Br[p];
-    if(NucDeEx::Utils::fVerbose>1){
-      std::cout << "Br_integ(" << NucDeEx::particle_name[p].substr(0,1) << ") = " << Br_integ << std::endl;
-    }
-    if(Br_integ>random){
-      decay_mode_r=p;
-      break; 
-    } 
-  }
-  if(decay_mode_r<0){
-    std::cerr << "Unexpected decay_mode = " << decay_mode_r << std::endl;
-    exit(1);
-  }
-
-  // --- Set Z and N for daughter 
-  Z_daughter = Z_target;
-  N_daughter = N_target;
-  if(decay_mode_r==1){
-    N_daughter--;
-  }else if(decay_mode_r==2){
-    Z_daughter--;
-  }else if(decay_mode_r==3){
-    Z_daughter--;
-    N_daughter--;
-  }else if(decay_mode_r==4){
-    Z_daughter--;
-    N_daughter-=2;
-  }else if(decay_mode_r==5){
-    Z_daughter-=2;
-    N_daughter--;
-  }else if(decay_mode_r==6){
-    Z_daughter-=2;
-    N_daughter-=2;
-  }
-  nuc_daughter = _nucleus_table->GetNucleusPtr(Z_daughter,N_daughter);
-  if(nuc_daughter!=NULL) name_daughter = nuc_daughter->name;
-  else{
-    os.str("");
-    os << Z_daughter+N_daughter << _nucleus_table->nuc_name[Z_daughter];
-    name_daughter = os.str();
-  }
-
-  if(NucDeEx::Utils::fVerbose>1){ 
-    std::cout << "DecayMode(): Random = " << random << " : " << name_target.c_str() << " --> " << NucDeEx::particle_name[decay_mode_r] << " + ";
-    std::cout << name_daughter.c_str() << std::endl;
-  }
-
-  return decay_mode_r;
-}
-
-/////////////////////////////////////////////
-int NucDeExDeexcitation::GetBrExTGraph(const string st, const double ex_t, const int mode)
-/////////////////////////////////////////////
-{
-  double ex,br;
-  double diff_ex=0;
-  int point=0;
-  for(point=0;point<g_br[mode]->GetN();point++){
-    g_br[mode]->GetPoint(point,ex,br);
-    if(ex>ex_t) break;
-    diff_ex = abs(ex-ex_t);
-  }
-  if(abs(ex-ex_t)>diff_ex) point--;
-  if(point==g_br[mode]->GetN()) point--;
-  if(point<0) point=0;
-  os.str("");
-  os << "g_" << st.c_str() << "_br_ex_" << mode << "_" << point;
-  g_br_ex = (TGraph*) rootf->Get(os.str().c_str());
-  if(g_br_ex==0) return -1; // no tgraph
-
-  if(g_br_ex->GetN()==0){ //no point in the tgraph -> get next point
-    point++;
-    os.str("");
-    os << "g_" << st.c_str() << "_br_ex_" << mode << "_" << point;
-    g_br_ex = (TGraph*) rootf->Get(os.str().c_str());
-    if(g_br_ex==0) return -1; // no tgraph
-  }
-  g_br[mode]->GetPoint(point,ex,br);
-
-  if(NucDeEx::Utils::fVerbose>1){
-    std::cout << "GetBrExTGraph(): nearest_point = " << point << ",  ex at the point = " << ex
-      << ", diff_Ex = " << abs(ex-ex_t) << ", diff_ex(previous) = " << diff_ex << std::endl;
-
-  }
-  if(ex==0 && point==0) return 0; // g.s.
-  return 1;
-}
-
-/////////////////////////////////////////////
-bool NucDeExDeexcitation::DaughterExPoint(double *d_Ex, int *d_point)
-/////////////////////////////////////////////
-{
-  double ex=0, br=0;
-  double Br_sum=0;
-  for(int p=0;p<g_br_ex->GetN();p++){
-    g_br_ex->GetPoint(p,ex,br);
-    Br_sum += br;
-  }
-  double Br_integ=0;
-  double random = NucDeEx::Random::random();
-  int point=0;
-  for(point=0;point<g_br_ex->GetN();point++){
-    g_br_ex->GetPoint(point,ex,br);
-    br /= Br_sum; // Normalize Br just in case.
-    Br_integ += br;
-    if(Br_integ>random) break;
-  }
-  if(NucDeEx::Utils::fVerbose>1){
-    std::cout << "DaughterExPoint: Random = " << random << " : ex = " << ex
-         << ",   point = " << point << std::endl;
-  }
-
-  *d_Ex=ex;
-  *d_point=point;
-
-  return 1;
-}
-
-/////////////////////////////////////////////
-int NucDeExDeexcitation::Decay(const bool breakflag)
-/////////////////////////////////////////////
-{
-  if(NucDeEx::Utils::fVerbose>0){
-    std::cout << "NucDeExDeexcitation::Decay()" << std::endl;
-  }
-  int status=1; // sucess
-
-  // ---- CM frame --- //
-  // --- Calculate kinematics (CM)
-  //    mass used in the following calculation should include excitation energy
-  double mass_ex_daughter = mass_daughter + Ex_daughter;
-
-  double cmMomentum = std::sqrt(Qvalue*(Qvalue + 2.*mass_particle)*
-                              (Qvalue + 2.*mass_ex_daughter)*
-                              (Qvalue + 2.*mass_particle + 2.*mass_ex_daughter) )/
-                              (Qvalue + mass_particle + mass_ex_daughter)/2.;
-  double kE_particle = sqrt( pow(cmMomentum,2) + pow(mass_particle,2) ) - mass_particle;
-  double kE_daughter = sqrt( pow(cmMomentum,2) + pow(mass_ex_daughter,2) ) - mass_ex_daughter;
-  double kE_sum = kE_particle + kE_daughter; // just for check
-  if( Qvalue>0 && (kE_sum - Qvalue)/Qvalue > check_criteria){
-    std::cerr << "Error @ NucDeExDeexcitationD::Decay: Something wrong in kinematics calculation" << std::endl;
-    status=0;
-  }
-  if(NucDeEx::Utils::fVerbose>1){
-    std::cout << "mass_target   = " << mass_target << std::endl;
-    std::cout << "mass_particle = " << mass_particle << std::endl;
-    std::cout << "mass_daughter = " << mass_daughter << std::endl;
-    std::cout << "cmMomentum  = " << cmMomentum << std::endl;
-    std::cout << "kE_particle = " << kE_particle << std::endl;
-    std::cout << "kE_daughter = " << kE_daughter << std::endl;
-    std::cout << "kE_sum      = " << kE_sum << " <- consistent with Qvalue = " << Qvalue << std::endl;
-  }
-  
-  // --- Detemine momentum direction (uniform) (CM)
-  // --- Then set momentum vectors
-  double costheta = 2.*NucDeEx::Random::random()-1.; // [-1, 1]
-  double sintheta = sqrt( 1. - pow(costheta,2) );
-  double phi      = 2*TMath::Pi()*NucDeEx::Random::random(); // [0,2pi]
-  TVector3 dir( sintheta*cos(phi), sintheta*sin(phi), costheta );
-  mom_particle = -1*cmMomentum*dir; // -P
-  mom_daughter = cmMomentum*dir; // P
-  if(NucDeEx::Utils::fVerbose>1){
-    std::cout << "dir:          "; dir.Print();
-    std::cout << "mom_particle: ";mom_particle.Print();
-    std::cout << "mom_daughter: ";mom_daughter.Print();
-  }
-  
-
-  // ---- CM -> LAB --- //
-  // --- Get total energy of target (i.e., CM frame) in the LAB frame for boost
-  //     This is "Total CM energy" (in the LAB frame)
-  //     This should not include excitation energy
-  double totalE_target = sqrt( pow(mom_target.Mag(),2) + pow(mass_target,2) );
-
-  // --- Store info as Particle. then boost it
-  NucDeExParticle p_particle(NucDeEx::PDG_particle[decay_mode],
-                      mass_particle,
-                      mom_particle,
-                      NucDeEx::particle_name[decay_mode],
-                      1,0);// trace flag==1, Ex_daughter==0
-  double totalE_particle_bef = p_particle.totalE();
-  p_particle.Boost(totalE_target,mom_target);// BOOST!
-  double totalE_particle_aft = p_particle.totalE();
-
-  NucDeExParticle p_daughter(PDGion(Z_daughter,N_daughter),
-                      mass_daughter, // w/o excitation E
-                      mom_daughter,
-                      name_daughter,
-                      0,Ex_daughter); // intermediate state in default
-
-  double totalE_daughter_bef = p_daughter.totalE();
-  p_daughter.Boost(totalE_target,mom_target);
-  double totalE_daughter_aft = p_daughter.totalE();
-
-  // 
-  double kE_target = totalE_target - mass_target;
-  double totalE_ex_target = totalE_target + Ex_target; // w/ excitation E
-
-  double totalE_bef = totalE_particle_bef + totalE_daughter_bef;
-  double totalE_aft = totalE_particle_aft + totalE_daughter_aft;
-  double totalE_ex_bef = totalE_bef + Ex_daughter; // w/ excitation E
-  double totalE_ex_aft = totalE_aft + Ex_daughter;
-
-  if(NucDeEx::Utils::fVerbose>1){
-    std::cout << "totalE_target = " << totalE_target << std::endl;
-    std::cout << "kE_target = " << kE_target << std::endl;
-    std::cout << "Ex_target = " << Ex_target << std::endl;
-    std::cout << "totalE_ex_target = " << totalE_ex_target << std::endl;
-    std::cout << "totalE_bef = " << totalE_bef << std::endl;
-    std::cout << "totalE_aft = " << totalE_aft << std::endl;
-    std::cout << "  diff = " << totalE_aft-totalE_bef << std::endl;
-    std::cout << "totalE_ex_bef = " << totalE_ex_bef << std::endl;
-    std::cout << "totalE_ex_aft = " << totalE_ex_aft << std::endl;
-  }
-
-
-  // --- Check Energy conservation (4dim energy including momentum)
-  //       Fundamental energy conservation 
-  //       (Total energy in LAB) = (Total energy in CM after boost)
-  // i.e., (Total energy of target w/ ex in LAB) 
-  //         = (Total energy of particle after boost) + (Total energy of daughter w/ ex after boost)
-  //            The last two terms are calculated from CM at first, and then boosted.
-  if(totalE_ex_target>0 && (totalE_ex_aft-totalE_ex_target)/totalE_ex_target>check_criteria){
-    std::cerr << "ERROR: @ NucDeExDeexcitation:Decay(): Energy is not conserved..." << std::endl;
-    status=0;
-  }
-
-  // Then, push back
-
-  EventInfo.ParticleVector->push_back(p_particle);
-  // DoDeex loop will be end -> turn on track flag, because it is not intermediate state
-  if(breakflag) p_daughter._flag=1;
-  EventInfo.ParticleVector->push_back(p_daughter);
-
-  if(NucDeEx::Utils::fVerbose>1){
-    std::cout << "flag_particle = " << p_particle._flag << std::endl;
-    std::cout << "flag_daughter = " << p_daughter._flag << std::endl;
-  }
-  return status;
-}
-
-/////////////////////////////////////////////
-double NucDeExDeexcitation::ElementMassInMeV(TGeoElementRN* ele)
-/////////////////////////////////////////////
-{
-  if(ele==0) return -1; // no profile can be found.
-  double mass = ele->MassNo()*NucDeEx::amu_c2
-                   + ele->MassEx(); // (MeV)
-  double mass_amu = mass/NucDeEx::amu_c2;
-  if(NucDeEx::Utils::fVerbose>1){
-    std::cout << "mass (MeV) = " << mass 
-         << "    (amu) = " << mass_amu << std::endl;
-  }
-  return mass;
-}
-
-/////////////////////////////////////////////
-int NucDeExDeexcitation::PDGion(int Z, int N)
-/////////////////////////////////////////////
-{
-  int pdg_int= 1e9 + Z*1e4 + (Z+N)*1e1;
-  return pdg_int;
-}
-
-
-/////////////////////////////////////////////
-bool NucDeExDeexcitation::OpenROOT(const int Zt,const int Nt, const int Z, const int N)
-/////////////////////////////////////////////
-{
-  os.str("");
-  os << NucDeEx::Utils::NUCDEEX_ROOT << "/output/";
-  // single nucleon hole
-  if( (Zt==Z && Nt==N+1) || (Zt==Z+1 && Nt==N) ){ 
-    if(Zt==6&&Nt==6) os << "12C/";
-    else if(Zt==8&&Nt==8) os << "16O/";
-    else return 0; // not supported
-  }
-  os << "Br_" << name_target.c_str() << "_ldmodel" << ldmodel;
-  if(parity_optmodall) os << "_parity_optmodall";
-  os << ".root"; 
-  //
-  rootf = new TFile(os.str().c_str(),"READ");
-  if(! rootf->IsOpen()) return 0;
-  if(NucDeEx::Utils::fVerbose>1){
-    std::cout << "OpenRoot: " << os.str().c_str() << std::endl;
-  }
-  return 1;
-}
-
-/////////////////////////////////////////////
-bool NucDeExDeexcitation::GetBrTGraph(const string st)
-/////////////////////////////////////////////
-{
-  for(int p=0;p<NucDeEx::num_particle;p++){
-    os.str("");
-    os << "g_" << st.c_str() << "_br_" << p;
-    g_br[p] = (TGraph*) rootf->Get(os.str().c_str());
-    if(g_br[p]==0) return 0; // no tgraph
-  }
-  return 1;
-}
-
-/////////////////////////////////////////////
-void NucDeExDeexcitation::DeleteTGraphs()
-/////////////////////////////////////////////
-{
-  for(int p=0;p<NucDeEx::num_particle;p++){
-    delete g_br[p];
-    g_br[p]=0;
-  }
-  delete g_br_ex;
-  g_br_ex=0;
-}

--- a/src/NucDeExDeexcitationBase.cc
+++ b/src/NucDeExDeexcitationBase.cc
@@ -1,0 +1,234 @@
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+#include <stdio.h>
+#include <string>
+#include <string.h>
+#include <cstdlib>
+#include <algorithm>
+#include <vector>
+
+#include "NucDeExUtils.hh"
+#include "NucDeExRandom.hh"
+#include "NucDeExParticle.hh"
+#include "NucDeExDeexcitationBase.hh"
+
+///////////////////////////
+NucDeExDeexcitationBase::NucDeExDeexcitationBase(): EventID(0)
+///////////////////////////
+{
+  if(NucDeEx::Utils::NucleusTable==NULL){
+    NucDeEx::Utils::NucleusTable = new NucDeExNucleusTable();
+  }
+  fTDatabasePDG = new TDatabasePDG();
+  fTGeoManager = new TGeoManager("NucDeEx","NucDeEx");
+  fTGeoElementTable = fTGeoManager->GetElementTable();
+}
+
+///////////////////////////
+NucDeExDeexcitationBase::~NucDeExDeexcitationBase()
+///////////////////////////
+{
+  delete fTDatabasePDG;
+  delete fTGeoManager;
+  //delete fTGeoElementTable;
+}
+
+///////////////////////////
+void NucDeExDeexcitationBase::Init()
+///////////////////////////
+{
+  NucDeEx::Utils::NucleusTable->ReadTables(0);
+}
+
+/////////////////////////////////////////////
+void NucDeExDeexcitationBase::SaveEventLevelInfo(const int Zt, const int Nt,
+                        const int Z, const int N,const double Ex, const TVector3& mom)
+/////////////////////////////////////////////
+{
+  // event level info
+  EventInfo.EventID = EventID;
+  EventInfo.Zt     = Zt;
+  EventInfo.Nt     = Nt;
+  EventInfo.Z      = Z;
+  EventInfo.N      = N;
+  EventInfo.Ex     = Ex;
+  EventInfo.Pinit  = mom;
+}
+
+/////////////////////////////////////////////
+bool NucDeExDeexcitationBase::Decay(const bool breakflag)
+/////////////////////////////////////////////
+{
+  if(NucDeEx::Utils::fVerbose>0){
+    std::cout << "NucDeExDeexcitationBase::Decay()" << std::endl;
+  }
+  bool status=1; // sucess
+
+  // ---- CM frame --- //
+  // --- Calculate kinematics (CM)
+  //    mass used in the following calculation should include excitation energy
+  double mass_ex_daughter = mass_daughter + Ex_daughter;
+
+  double cmMomentum = std::sqrt(Qvalue*(Qvalue + 2.*mass_particle)*
+                              (Qvalue + 2.*mass_ex_daughter)*
+                              (Qvalue + 2.*mass_particle + 2.*mass_ex_daughter) )/
+                              (Qvalue + mass_particle + mass_ex_daughter)/2.;
+  double kE_particle = sqrt( pow(cmMomentum,2) + pow(mass_particle,2) ) - mass_particle;
+  double kE_daughter = sqrt( pow(cmMomentum,2) + pow(mass_ex_daughter,2) ) - mass_ex_daughter;
+  double kE_sum = kE_particle + kE_daughter; // just for check
+  if( Qvalue>0 && (kE_sum - Qvalue)/Qvalue > check_criteria){
+    std::cerr << "WARNING @ NucDeExDeexcitationBase::Decay: Something wrong in kinematics calculation" << std::endl;
+    status=0;
+  }
+  if(NucDeEx::Utils::fVerbose>1){
+    std::cout << "mass_target   = " << mass_target << std::endl;
+    std::cout << "mass_particle = " << mass_particle << std::endl;
+    std::cout << "mass_daughter = " << mass_daughter << std::endl;
+    std::cout << "cmMomentum  = " << cmMomentum << std::endl;
+    std::cout << "kE_particle = " << kE_particle << std::endl;
+    std::cout << "kE_daughter = " << kE_daughter << std::endl;
+    std::cout << "kE_sum      = " << kE_sum << " <- consistent with Qvalue = " << Qvalue << std::endl;
+  }
+  
+  // --- Detemine momentum direction (uniform) (CM)
+  // --- Then set momentum vectors
+  double costheta = 2.*NucDeEx::Random::random()-1.; // [-1, 1]
+  double sintheta = sqrt( 1. - pow(costheta,2) );
+  double phi      = 2*TMath::Pi()*NucDeEx::Random::random(); // [0,2pi]
+  TVector3 dir( sintheta*cos(phi), sintheta*sin(phi), costheta );
+  mom_particle = -1*cmMomentum*dir; // -P
+  mom_daughter = cmMomentum*dir; // P
+  if(NucDeEx::Utils::fVerbose>1){
+    std::cout << "dir:          "; dir.Print();
+    std::cout << "mom_particle: ";mom_particle.Print();
+    std::cout << "mom_daughter: ";mom_daughter.Print();
+  }
+  
+
+  // ---- CM -> LAB --- //
+  // --- Get total energy of target (i.e., CM frame) in the LAB frame for boost
+  //     This is "Total CM energy" (in the LAB frame)
+  //     This should not include excitation energy
+  double totalE_target = sqrt( pow(mom_target.Mag(),2) + pow(mass_target,2) );
+
+  // --- Store info as Particle. then boost it
+  NucDeExParticle p_particle(NucDeEx::PDG_particle[decay_mode],
+                      mass_particle,
+                      mom_particle,
+                      NucDeEx::particle_name[decay_mode],
+                      1,0);// trace flag==1, Ex_daughter==0
+  double totalE_particle_bef = p_particle.totalE();
+  p_particle.Boost(totalE_target,mom_target);// BOOST!
+  double totalE_particle_aft = p_particle.totalE();
+
+  NucDeExParticle p_daughter(PDGion(Z_daughter,N_daughter),
+                      mass_daughter, // w/o excitation E
+                      mom_daughter,
+                      name_daughter,
+                      0,Ex_daughter); // intermediate state in default
+
+  double totalE_daughter_bef = p_daughter.totalE();
+  p_daughter.Boost(totalE_target,mom_target);
+  double totalE_daughter_aft = p_daughter.totalE();
+
+  // 
+  double kE_target = totalE_target - mass_target;
+  double totalE_ex_target = totalE_target + Ex_target; // w/ excitation E
+
+  double totalE_bef = totalE_particle_bef + totalE_daughter_bef;
+  double totalE_aft = totalE_particle_aft + totalE_daughter_aft;
+  double totalE_ex_bef = totalE_bef + Ex_daughter; // w/ excitation E
+  double totalE_ex_aft = totalE_aft + Ex_daughter;
+
+  if(NucDeEx::Utils::fVerbose>1){
+    std::cout << "totalE_target = " << totalE_target << std::endl;
+    std::cout << "kE_target = " << kE_target << std::endl;
+    std::cout << "Ex_target = " << Ex_target << std::endl;
+    std::cout << "totalE_ex_target = " << totalE_ex_target << std::endl;
+    std::cout << "totalE_bef = " << totalE_bef << std::endl;
+    std::cout << "totalE_aft = " << totalE_aft << std::endl;
+    std::cout << "  diff = " << totalE_aft-totalE_bef << std::endl;
+    std::cout << "totalE_ex_bef = " << totalE_ex_bef << std::endl;
+    std::cout << "totalE_ex_aft = " << totalE_ex_aft << std::endl;
+  }
+
+
+  // --- Check Energy conservation (4dim energy including momentum)
+  //       Fundamental energy conservation 
+  //       (Total energy in LAB) = (Total energy in CM after boost)
+  // i.e., (Total energy of target w/ ex in LAB) 
+  //         = (Total energy of particle after boost) + (Total energy of daughter w/ ex after boost)
+  //            The last two terms are calculated from CM at first, and then boosted.
+  if(totalE_ex_target>0 && (totalE_ex_aft-totalE_ex_target)/totalE_ex_target>check_criteria){
+    std::cerr << "WARNING: @ NucDeExDeexcitation:Decay(): Energy is not conserved..." << std::endl;
+    status=0;
+  }
+
+  // Then, push back
+  EventInfo.ParticleVector.push_back(p_particle);
+  // DoDeex loop will be end -> turn on track flag, because it is not intermediate state
+  if(breakflag) p_daughter._flag=1;
+  EventInfo.ParticleVector.push_back(p_daughter);
+
+  if(NucDeEx::Utils::fVerbose>1){
+    std::cout << "flag_particle = " << p_particle._flag << std::endl;
+    std::cout << "flag_daughter = " << p_daughter._flag << std::endl;
+  }
+  return status;
+}
+
+/////////////////////////////////////////////
+void NucDeExDeexcitationBase::AddGSNucleus(const int Z,const int N, const TVector3& mom)
+/////////////////////////////////////////////
+{
+  double mass_target = ElementMassInMeV(Z+N, Z);
+  NucDeExNucleus* nuc_target = NucDeEx::Utils::NucleusTable->GetNucleusPtr(Z,N);
+  if(nuc_target==NULL || mass_target<0){
+    EventInfo.fStatus=0;
+    return; // no particle is added to the vector
+  }
+  string name_target = (string)nuc_target->name;
+  NucDeExParticle nucleus(PDGion(Z,N),
+                          mass_target, // w/o excitation E
+                          mom,
+                          name_target, 
+                          1,0); // track flag on // zero ex
+  if(NucDeEx::Utils::fVerbose>0){
+    std::cout << "AddGSNucleus(): " << name_target << std::endl;
+  }
+  EventInfo.fStatus=1;
+  EventInfo.ParticleVector.push_back(nucleus);
+  return;
+}
+
+/////////////////////////////////////////////
+const double NucDeExDeexcitationBase::ElementMassInMeV(const int A, const int Z)
+/////////////////////////////////////////////
+{
+  return ElementMassInMeV( fTGeoElementTable->GetElementRN(A,Z) );
+}
+
+/////////////////////////////////////////////
+const double NucDeExDeexcitationBase::ElementMassInMeV(const TGeoElementRN* ele)
+/////////////////////////////////////////////
+{
+  if(ele==0) return -1; // no profile can be found.
+  double mass = ele->MassNo()*NucDeEx::amu_c2
+                   + ele->MassEx(); // (MeV)
+  double mass_amu = mass/NucDeEx::amu_c2;
+  if(NucDeEx::Utils::fVerbose>1){
+    std::cout << "mass (MeV) = " << mass 
+         << "    (amu) = " << mass_amu << std::endl;
+  }
+  return mass;
+}
+
+/////////////////////////////////////////////
+const int NucDeExDeexcitationBase::PDGion(const int Z, const int N)
+/////////////////////////////////////////////
+{
+  int pdg_int= 1e9 + Z*1e4 + (Z+N)*1e1;
+  return pdg_int;
+}

--- a/src/NucDeExDeexcitationBase.cc
+++ b/src/NucDeExDeexcitationBase.cc
@@ -17,28 +17,18 @@
 ///////////////////////////
 NucDeExDeexcitationBase::NucDeExDeexcitationBase(): EventID(0)
 ///////////////////////////
-{
-  if(NucDeEx::Utils::NucleusTable==NULL){
-    NucDeEx::Utils::NucleusTable = new NucDeExNucleusTable();
-  }
-  fTDatabasePDG = new TDatabasePDG();
-  fTGeoManager = new TGeoManager("NucDeEx","NucDeEx");
-  fTGeoElementTable = fTGeoManager->GetElementTable();
-}
+{}
 
 ///////////////////////////
 NucDeExDeexcitationBase::~NucDeExDeexcitationBase()
 ///////////////////////////
-{
-  delete fTDatabasePDG;
-  delete fTGeoManager;
-  //delete fTGeoElementTable;
-}
+{}
 
 ///////////////////////////
 void NucDeExDeexcitationBase::Init()
 ///////////////////////////
 {
+  NucDeEx::Utils::Init();
   NucDeEx::Utils::NucleusTable->ReadTables(0);
 }
 
@@ -207,7 +197,7 @@ void NucDeExDeexcitationBase::AddGSNucleus(const int Z,const int N, const TVecto
 const double NucDeExDeexcitationBase::ElementMassInMeV(const int A, const int Z)
 /////////////////////////////////////////////
 {
-  return ElementMassInMeV( fTGeoElementTable->GetElementRN(A,Z) );
+  return ElementMassInMeV( NucDeEx::Utils::fTGeoElementTable->GetElementRN(A,Z) );
 }
 
 /////////////////////////////////////////////

--- a/src/NucDeExDeexcitationBase.cc
+++ b/src/NucDeExDeexcitationBase.cc
@@ -17,20 +17,14 @@
 ///////////////////////////
 NucDeExDeexcitationBase::NucDeExDeexcitationBase(): EventID(0)
 ///////////////////////////
-{}
+{
+  NucDeEx::Utils::Init();
+}
 
 ///////////////////////////
 NucDeExDeexcitationBase::~NucDeExDeexcitationBase()
 ///////////////////////////
 {}
-
-///////////////////////////
-void NucDeExDeexcitationBase::Init()
-///////////////////////////
-{
-  NucDeEx::Utils::Init();
-  NucDeEx::Utils::NucleusTable->ReadTables(0);
-}
 
 /////////////////////////////////////////////
 void NucDeExDeexcitationBase::SaveEventLevelInfo(const int Zt, const int Nt,

--- a/src/NucDeExDeexcitationPhole.cc
+++ b/src/NucDeExDeexcitationPhole.cc
@@ -197,5 +197,7 @@ NucDeExEventInfo NucDeExDeexcitationPhole::DoDeex(const int Zt, const int Nt,
   }else{ 
     exit(1);
   }
+
+  EventInfo.fShell=2; // overwrite
   return EventInfo;
 }

--- a/src/NucDeExDeexcitationPhole.cc
+++ b/src/NucDeExDeexcitationPhole.cc
@@ -1,0 +1,201 @@
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+#include <stdio.h>
+#include <string>
+#include <string.h>
+#include <cstdlib>
+#include <algorithm>
+#include <vector>
+
+#include "NucDeExUtils.hh"
+#include "NucDeExRandom.hh"
+#include "NucDeExDeexcitationPhole.hh"
+
+
+///////////////////////////
+NucDeExDeexcitationPhole::NucDeExDeexcitationPhole(): flag_model(0)
+///////////////////////////
+{}
+///////////////////////////
+NucDeExDeexcitationPhole::NucDeExDeexcitationPhole(int f): flag_model(f)
+///////////////////////////
+{}
+
+
+/////////////////////////////////////////////
+NucDeExEventInfo NucDeExDeexcitationPhole::DoDeex(const int Zt, const int Nt,
+                   const int Z, const int N, const double Ex, const TVector3& mom)
+/////////////////////////////////////////////
+{
+  if(NucDeEx::Utils::fVerbose>0) std::cout << "NucDeExDeexcitationPholeDoDeex()  Z=" << Z << "   N=" << N << endl;
+  EventID++;
+
+  // --- Save event level info (except for shell & status) --- //
+  EventInfo.InitParameters();
+  SaveEventLevelInfo(Zt,Nt,Z,N,Ex,mom);
+
+  // store target info
+  Z_target   = Z;
+  N_target   = N;
+  mom_target = mom;
+  nuc_target = NucDeEx::Utils::NucleusTable->GetNucleusPtr(Z_target,N_target);
+  name_target = (string)nuc_target->name;
+
+  double random = NucDeEx::Random::random();
+
+  //-----------11B------------//
+  if(Z==5 && N==6){
+  //--------------------------//
+    int index=0;
+    double Br_integ=0;
+    for(int i=0;i<Nlevel_p32_11B;i++){
+      Br_integ += Br_p32_11B[i];
+      if(random<Br_integ){
+        index=i;
+        break;
+      }
+    }
+    if(index==0){ // g.s.
+      AddGSNucleus(Z,N,mom);
+    }else{ // excited state
+      // set paremeters for boost calculation
+      decay_mode=0; 
+      Ex_target  = E_p32_11B[index];
+      Ex_daughter=0;
+      mass_particle=0;
+      mass_target = ElementMassInMeV(Z_target+N_target, Z_target);
+      mass_daughter=mass_target;
+      name_daughter = name_target;
+      Z_daughter = Z_target;
+      N_daughter = N_target;
+      nuc_daughter = nuc_target;
+      S = nuc_target->S[decay_mode];
+      Qvalue = Ex_target - S - Ex_daughter;
+      Decay(1); // breakflag on
+    }
+  //-----------11C------------//
+  }else if(Z==6 && N==5){
+  //--------------------------//
+    int index=0;
+    double Br_integ=0;
+    for(int i=0;i<Nlevel_p32_11C;i++){
+      Br_integ += Br_p32_11C[i];
+      if(random<Br_integ){
+        index=i;
+        break;
+      }
+    }
+    if(index==0){ // g.s.
+      AddGSNucleus(Z,N,mom);
+    }else{ // excited state
+      // set paremeters for boost calculation
+      decay_mode=0; 
+      Ex_target  = E_p32_11C[index];
+      Ex_daughter=0;
+      mass_particle=0;
+      mass_target = ElementMassInMeV(Z_target+N_target, Z_target);
+      mass_daughter=mass_target;
+      name_daughter = name_target;
+      Z_daughter = Z_target;
+      N_daughter = N_target;
+      nuc_daughter = nuc_target;
+      S = nuc_target->S[decay_mode];
+      Qvalue = Ex_target - S - Ex_daughter;
+      Decay(1); // breakflag on
+    }
+  //-----------15N------------//
+  }else if(Z==7 && N==8){
+  //--------------------------//
+    int index=0;
+    double Br_integ=0;
+    for(int i=0;i<Nlevel_p32_15N;i++){
+      Br_integ += Br_p32_15N[i];
+      if(random<Br_integ){
+        index=i;
+        break;
+      }
+    }
+    if(index==0){ // gamma
+      // set paremeters for boost calculation
+      decay_mode=0; 
+      Ex_target  = E_p32_15N[index];
+      Ex_daughter=0;
+      mass_particle=0;
+      mass_target = ElementMassInMeV(Z_target+N_target, Z_target);
+      mass_daughter=mass_target;
+      name_daughter = name_target;
+      Z_daughter = Z_target;
+      N_daughter = N_target;
+      nuc_daughter = nuc_target;
+      S = nuc_target->S[decay_mode];
+      Qvalue = Ex_target - S - Ex_daughter;
+      Decay(1); // breakflag on
+    }else if(index==1){ // gamma but multiple -> read talys
+      EventInfo = deex_talys->DoDeex(Zt,Nt,Z,N,E_p32_15N[index],mom);
+    }else if(index==2){
+      // set paremeters for boost calculation
+      decay_mode=2; // proton
+      Ex_target  = E_p32_15N[index];
+      Ex_daughter=0;
+      mass_particle = fTDatabasePDG->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
+      mass_target = ElementMassInMeV(Z_target+N_target, Z_target);
+      Z_daughter = Z_target-1;
+      N_daughter = N_target;
+      mass_daughter = ElementMassInMeV(Z_daughter+N_daughter, Z_daughter);
+      nuc_daughter = NucDeEx::Utils::NucleusTable->GetNucleusPtr(Z_daughter,N_daughter);
+      name_daughter = nuc_daughter->name;
+      S = nuc_target->S[decay_mode];
+      Qvalue = Ex_target - S - Ex_daughter;
+      Decay(1); // breakflag on
+    }else{
+      exit(1);
+    }
+  //-----------15O------------//
+  }else if(Z==8 && N==7){
+  //--------------------------//
+    int index=0;
+    double Br_integ=0;
+    for(int i=0;i<Nlevel_p32_15O;i++){
+      Br_integ += Br_p32_15O[i];
+      if(random<Br_integ){
+        index=i;
+        break;
+      }
+    }
+    if(index==0){ // gamma
+      // set paremeters for boost calculation
+      decay_mode=0; 
+      Ex_target  = E_p32_15O[index];
+      Ex_daughter=0;
+      mass_particle=0;
+      mass_target = ElementMassInMeV(Z_target+N_target, Z_target);
+      mass_daughter=mass_target;
+      name_daughter = name_target;
+      Z_daughter = Z_target;
+      N_daughter = N_target;
+      S = nuc_target->S[decay_mode];
+      Qvalue = Ex_target - S - Ex_daughter;
+      Decay(1); // breakflag on
+    }else if(index==1||index==2){
+      // set paremeters for boost calculation
+      decay_mode=2; // proton
+      Ex_target  = E_p32_15O[index];
+      Ex_daughter=0;
+      mass_particle = fTDatabasePDG->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
+      mass_target = ElementMassInMeV(Z_target+N_target, Z_target);
+      Z_daughter = Z_target-1;
+      N_daughter = N_target;
+      mass_daughter = ElementMassInMeV(Z_daughter+N_daughter, Z_daughter);
+      nuc_daughter = NucDeEx::Utils::NucleusTable->GetNucleusPtr(Z_daughter,N_daughter);
+      name_daughter = nuc_daughter->name;
+      S = nuc_target->S[decay_mode];
+      Qvalue = Ex_target - S - Ex_daughter;
+      Decay(1); // breakflag on
+    }
+  }else{ 
+    exit(1);
+  }
+  return EventInfo;
+}

--- a/src/NucDeExDeexcitationPhole.cc
+++ b/src/NucDeExDeexcitationPhole.cc
@@ -17,15 +17,11 @@
 ///////////////////////////
 NucDeExDeexcitationPhole::NucDeExDeexcitationPhole(): flag_model(0)
 ///////////////////////////
-{
-  Init();
-}
+{}
 ///////////////////////////
 NucDeExDeexcitationPhole::NucDeExDeexcitationPhole(int f): flag_model(f)
 ///////////////////////////
-{
-  Init();
-}
+{}
 
 
 /////////////////////////////////////////////

--- a/src/NucDeExDeexcitationPhole.cc
+++ b/src/NucDeExDeexcitationPhole.cc
@@ -17,11 +17,15 @@
 ///////////////////////////
 NucDeExDeexcitationPhole::NucDeExDeexcitationPhole(): flag_model(0)
 ///////////////////////////
-{}
+{
+  Init();
+}
 ///////////////////////////
 NucDeExDeexcitationPhole::NucDeExDeexcitationPhole(int f): flag_model(f)
 ///////////////////////////
-{}
+{
+  Init();
+}
 
 
 /////////////////////////////////////////////
@@ -139,7 +143,7 @@ NucDeExEventInfo NucDeExDeexcitationPhole::DoDeex(const int Zt, const int Nt,
       decay_mode=2; // proton
       Ex_target  = E_p32_15N[index];
       Ex_daughter=0;
-      mass_particle = fTDatabasePDG->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
+      mass_particle = NucDeEx::Utils::fTDatabasePDG->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
       mass_target = ElementMassInMeV(Z_target+N_target, Z_target);
       Z_daughter = Z_target-1;
       N_daughter = N_target;
@@ -183,7 +187,7 @@ NucDeExEventInfo NucDeExDeexcitationPhole::DoDeex(const int Zt, const int Nt,
       decay_mode=2; // proton
       Ex_target  = E_p32_15O[index];
       Ex_daughter=0;
-      mass_particle = fTDatabasePDG->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
+      mass_particle = NucDeEx::Utils::fTDatabasePDG->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
       mass_target = ElementMassInMeV(Z_target+N_target, Z_target);
       Z_daughter = Z_target-1;
       N_daughter = N_target;

--- a/src/NucDeExDeexcitationTALYS.cc
+++ b/src/NucDeExDeexcitationTALYS.cc
@@ -24,7 +24,7 @@ NucDeExDeexcitationTALYS::NucDeExDeexcitationTALYS(const int ld, const bool p_o)
   ldmodel=ld;
   parity_optmodall=p_o;
   NucDeEx::Utils::SetPATH();
-  Init();
+  NucDeEx::Utils::NucleusTable->ReadTables(0); // should be after SetPATH
 }
 
 #ifdef INCL_DEEXCITATION_NUCDEEX
@@ -34,8 +34,7 @@ NucDeExDeexcitationTALYS::NucDeExDeexcitationTALYS(const int ld, const bool p_o,
 { 
   ldmodel=ld;
   parity_optmodall=p_o;
-  NucDeEx::Utils::SetPATH(config);
-  Init();
+  NucDeEx::Utils::NucleusTable->ReadTables(0); // should be after SetPATH
 }
 #endif
 

--- a/src/NucDeExDeexcitationTALYS.cc
+++ b/src/NucDeExDeexcitationTALYS.cc
@@ -108,7 +108,7 @@ NucDeExEventInfo NucDeExDeexcitationTALYS::DoDeex(const int Zt, const int Nt,
 
       // --- Get mass using ROOT libraries
       if(decay_mode<=2){ // obtained from TDatabasePDG
-        mass_particle = fTDatabasePDG->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
+        mass_particle = NucDeEx::Utils::fTDatabasePDG->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
       }else{ // obtained from TGeoElementRN
         int a_particle = (NucDeEx::PDG_particle[decay_mode]%1000)/10;
         int z_particle = ((NucDeEx::PDG_particle[decay_mode]%1000000)-a_particle*10)/10000;

--- a/src/NucDeExDeexcitationTALYS.cc
+++ b/src/NucDeExDeexcitationTALYS.cc
@@ -52,6 +52,7 @@ NucDeExEventInfo NucDeExDeexcitationTALYS::DoDeex(const int Zt, const int Nt,
   // --- Save event level info (except for shell & status) --- //
   EventInfo.InitParameters();
   SaveEventLevelInfo(Zt,Nt,Z,N,Ex,mom);
+  EventInfo.fShell=1;
 
   // --- store target info --- //
   Z_target   = Z;

--- a/src/NucDeExDeexcitationTALYS.cc
+++ b/src/NucDeExDeexcitationTALYS.cc
@@ -1,0 +1,371 @@
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+#include <stdio.h>
+#include <string>
+#include <string.h>
+#include <cstdlib>
+#include <algorithm>
+#include <vector>
+
+#include "NucDeExUtils.hh"
+#include "NucDeExRandom.hh"
+#include "NucDeExDeexcitationTALYS.hh"
+
+///////////////////////////
+NucDeExDeexcitationTALYS::NucDeExDeexcitationTALYS(): ldmodel(2), parity_optmodall(1){};
+///////////////////////////
+
+///////////////////////////
+NucDeExDeexcitationTALYS::NucDeExDeexcitationTALYS(const int ld, const bool p_o)
+///////////////////////////
+{
+  ldmodel=ld;
+  parity_optmodall=p_o;
+  NucDeEx::Utils::SetPATH();
+  Init();
+}
+
+#ifdef INCL_DEEXCITATION_NUCDEEX
+///////////////////////////
+NucDeExDeexcitationTALYS::NucDeExDeexcitationTALYS(const int ld, const bool p_o, G4INCL::Config *config)
+///////////////////////////
+{ 
+  ldmodel=ld;
+  parity_optmodall=p_o;
+  NucDeEx::Utils::SetPATH(config);
+  Init();
+}
+#endif
+
+/////////////////////////////////////////////
+NucDeExEventInfo NucDeExDeexcitationTALYS::DoDeex(const int Zt, const int Nt,
+                   const int Z, const int N, const double Ex, const TVector3& mom)
+/////////////////////////////////////////////
+{
+  if(NucDeEx::Utils::fVerbose>0) std::cout << "NucDeExDeexcitationTALYS::DoDeex()" << std::endl;
+  EventID++;
+
+  RESET:
+
+  // --- Save event level info (except for shell & status) --- //
+  EventInfo.InitParameters();
+  SaveEventLevelInfo(Zt,Nt,Z,N,Ex,mom);
+
+  // --- store target info --- //
+  Z_target   = Z;
+  N_target   = N;
+  Ex_target  = Ex;
+  if(Ex_target<0) Ex_target=0;
+  mom_target = mom;
+  nuc_target = NucDeEx::Utils::NucleusTable->GetNucleusPtr(Z_target,N_target);
+  if(nuc_target==NULL){ // nothing can be done for this case...(no mass profile)
+    if(NucDeEx::Utils::fVerbose>0){
+      std::cout << "We don't have deexcitation profile for this nucleus: "
+           << name_target.c_str() << std::endl;
+    }
+    EventInfo.fStatus=0;
+    return EventInfo;
+  }
+  name_target = (string) nuc_target->name;
+
+  // --- Read ROOT file --- //
+  if( ! OpenROOT(Zt,Nt,Z,N) ){ // No ROOT file
+    if(NucDeEx::Utils::fVerbose>0){
+      std::cout << "We don't have deexcitation profile for this nucleus: " << name_target.c_str() << std::endl;
+    }
+    AddGSNucleus(Z,N,mom);
+    EventInfo.fStatus=0;
+    return EventInfo;
+  }
+
+  int status=1;
+  
+  // Loop until zero excitation energy or null nuc_daughter ptr
+  // Use private members (parameters) named as "_target"
+  while(true){// <- infinite loop. There is break point
+    if(NucDeEx::Utils::fVerbose>0){
+      std::cout << "### " << name_target << ",   Ex = " << Ex_target << "   mom_target: "; mom_target.Print();
+    }
+
+    // --- Get (TGraph*) br based on name_target
+    if(GetBrTGraph(name_target)){ // TGraph found
+      // --- Determine decay mode 
+      //     Return: The same as array in NucDeExConsts.hh
+      decay_mode = DecayMode(Ex_target); 
+
+      // --- Get nearest Ex bin (TGraph point) and then get (TGraph*) br_ex
+      if(GetBrExTGraph(name_target, Ex_target, decay_mode)==0){ // g.s.
+        AddGSNucleus(Z,N,mom);
+        return EventInfo;
+      }
+
+      // --- Determine daughter excitation energy
+      int Ex_daughter_point;
+      DaughterExPoint(&Ex_daughter,&Ex_daughter_point);
+
+      // --- Get mass using ROOT libraries
+      if(decay_mode<=2){ // obtained from TDatabasePDG
+        mass_particle = fTDatabasePDG->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
+      }else{ // obtained from TGeoElementRN
+        int a_particle = (NucDeEx::PDG_particle[decay_mode]%1000)/10;
+        int z_particle = ((NucDeEx::PDG_particle[decay_mode]%1000000)-a_particle*10)/10000;
+        mass_particle = ElementMassInMeV(a_particle,z_particle);
+        if(NucDeEx::Utils::fVerbose>1) std::cout << "a_particle = " << a_particle << "   z_particle = " << z_particle << std::endl;
+      }
+      mass_target = ElementMassInMeV(Z_target+N_target, Z_target);
+      mass_daughter = ElementMassInMeV(Z_daughter+N_daughter, Z_daughter);
+      if(mass_target<0 || mass_daughter<0){// this rarely happens...
+        if(NucDeEx::Utils::fVerbose>0){
+          std::cout << "Cannot find " << name_daughter << " in TGeoElementRN" << std::endl;
+          std::cout << "Call DoDeex() again!" << std::endl;
+        }
+        goto RESET; // call this fuction again
+      }
+    }else{ // no tgraph found -> gamma emission to g.s.
+      if(NucDeEx::Utils::fVerbose>0){
+        std::cout << "Cannot find TGraph" << std::endl;
+        std::cout << "Force gamma decay" << std::endl;
+      }
+      decay_mode=0; 
+      Ex_daughter=0;
+      mass_particle=0;
+      mass_daughter=mass_target;
+    }
+
+    // --- Get separation E and Qvalue 
+    S = nuc_target->S[decay_mode];
+    Qvalue = Ex_target - S - Ex_daughter;
+    if(Qvalue<0) Qvalue=0;
+    if(NucDeEx::Utils::fVerbose>1){
+      std::cout << "S = " << S << std::endl;
+      std::cout << "Qvalue = " << Qvalue << std::endl;
+    }
+
+    bool breakflag=0;
+    if(nuc_daughter==NULL || Ex_daughter==0) breakflag=1;
+    
+    // --- Calculate kinematics --- //
+    if(Decay(breakflag)==0) status=-1; 
+      // if breakflag==0, it does not save daughter nucleus
+      // return 0: Something suspicious thing happens in energy conservation
+
+    if(breakflag) break;
+
+    // end of while loop: daughter -> target 
+    Z_target  = Z_daughter;
+    N_target  = N_daughter;
+    Ex_target = Ex_daughter;
+    mass_target = mass_daughter;
+    mom_target  += mom_daughter;
+    nuc_target = nuc_daughter;
+    name_target = (string)nuc_target->name;
+    if(NucDeEx::Utils::fVerbose>0) std::cout << std::endl;
+
+    // --- Need this to release memory of TGraph
+    //    TGraph memory looks not relased only by closing & deleting root file...
+    DeleteTGraphs();
+  }
+
+
+
+  rootf->Close();
+  delete rootf;
+  EventInfo.fStatus = status;
+  return EventInfo;
+}
+
+
+/////////////////////////////////////////////
+int NucDeExDeexcitationTALYS::DecayMode(const double Ex)
+/////////////////////////////////////////////
+{
+  // --- Determine decay mode 
+  // ---- Return: (int)decay_mode_r 
+
+  double Br[NucDeEx::num_particle]={0};
+  double Br_sum=0;
+  for(int p=0;p<NucDeEx::num_particle;p++){
+    Br[p] = g_br[p]->Eval(Ex);
+    if(Br[p]<0) Br[p]=0;
+    Br_sum += Br[p];
+    if(NucDeEx::Utils::fVerbose>1){
+      std::cout << "Br(" << NucDeEx::particle_name[p].substr(0,1) << ") = " << Br[p] << std::endl;
+    }
+  }
+
+  double Br_integ=0;
+  double random = NucDeEx::Random::random();
+  int decay_mode_r=-1;
+  for(int p=0;p<NucDeEx::num_particle;p++){
+    Br[p] /= Br_sum; // Normalize Br just in case.  
+    Br_integ += Br[p];
+    if(NucDeEx::Utils::fVerbose>1){
+      std::cout << "Br_integ(" << NucDeEx::particle_name[p].substr(0,1) << ") = " << Br_integ << std::endl;
+    }
+    if(Br_integ>random){
+      decay_mode_r=p;
+      break; 
+    } 
+  }
+  if(decay_mode_r<0){
+    std::cerr << "Unexpected decay_mode = " << decay_mode_r << std::endl;
+    exit(1);
+  }
+
+  // --- Set Z and N for daughter 
+  Z_daughter = Z_target;
+  N_daughter = N_target;
+  if(decay_mode_r==1){
+    N_daughter--;
+  }else if(decay_mode_r==2){
+    Z_daughter--;
+  }else if(decay_mode_r==3){
+    Z_daughter--;
+    N_daughter--;
+  }else if(decay_mode_r==4){
+    Z_daughter--;
+    N_daughter-=2;
+  }else if(decay_mode_r==5){
+    Z_daughter-=2;
+    N_daughter--;
+  }else if(decay_mode_r==6){
+    Z_daughter-=2;
+    N_daughter-=2;
+  }
+  nuc_daughter = NucDeEx::Utils::NucleusTable->GetNucleusPtr(Z_daughter,N_daughter);
+  if(nuc_daughter!=NULL) name_daughter = nuc_daughter->name;
+  else{
+    os.str("");
+    os << Z_daughter+N_daughter << NucDeEx::Utils::NucleusTable->nuc_name[Z_daughter];
+    name_daughter = os.str();
+  }
+
+  if(NucDeEx::Utils::fVerbose>1){ 
+    std::cout << "DecayMode(): Random = " << random << " : " << name_target.c_str() << " --> " << NucDeEx::particle_name[decay_mode_r] << " + ";
+    std::cout << name_daughter.c_str() << std::endl;
+  }
+
+  return decay_mode_r;
+}
+
+/////////////////////////////////////////////
+bool NucDeExDeexcitationTALYS::OpenROOT(const int Zt,const int Nt, const int Z, const int N)
+/////////////////////////////////////////////
+{
+  os.str("");
+  os << NucDeEx::Utils::NUCDEEX_ROOT << "/output/";
+  // single nucleon hole
+  if( (Zt==Z && Nt==N+1) || (Zt==Z+1 && Nt==N) ){ 
+    if(Zt==6&&Nt==6) os << "12C/";
+    else if(Zt==8&&Nt==8) os << "16O/";
+    else return 0; // not supported
+  }
+  os << "Br_" << name_target.c_str() << "_ldmodel" << ldmodel;
+  if(parity_optmodall) os << "_parity_optmodall";
+  os << ".root"; 
+  //
+  rootf = new TFile(os.str().c_str(),"READ");
+  if(! rootf->IsOpen()) return 0;
+  if(NucDeEx::Utils::fVerbose>1){
+    std::cout << "OpenRoot: " << os.str().c_str() << std::endl;
+  }
+  return 1;
+}
+
+/////////////////////////////////////////////
+bool NucDeExDeexcitationTALYS::GetBrTGraph(const string st)
+/////////////////////////////////////////////
+{
+  for(int p=0;p<NucDeEx::num_particle;p++){
+    os.str("");
+    os << "g_" << st.c_str() << "_br_" << p;
+    g_br[p] = (TGraph*) rootf->Get(os.str().c_str());
+    if(g_br[p]==0) return 0; // no tgraph
+  }
+  return 1;
+}
+
+
+/////////////////////////////////////////////
+int NucDeExDeexcitationTALYS::GetBrExTGraph(const string st, const double ex_t, const int mode)
+/////////////////////////////////////////////
+{
+  double ex,br;
+  double diff_ex=0;
+  int point=0;
+  for(point=0;point<g_br[mode]->GetN();point++){
+    g_br[mode]->GetPoint(point,ex,br);
+    if(ex>ex_t) break;
+    diff_ex = abs(ex-ex_t);
+  }
+  if(abs(ex-ex_t)>diff_ex) point--;
+  if(point==g_br[mode]->GetN()) point--;
+  if(point<0) point=0;
+  os.str("");
+  os << "g_" << st.c_str() << "_br_ex_" << mode << "_" << point;
+  g_br_ex = (TGraph*) rootf->Get(os.str().c_str());
+  if(g_br_ex==0) return -1; // no tgraph
+
+  if(g_br_ex->GetN()==0){ //no point in the tgraph -> get next point
+    point++;
+    os.str("");
+    os << "g_" << st.c_str() << "_br_ex_" << mode << "_" << point;
+    g_br_ex = (TGraph*) rootf->Get(os.str().c_str());
+    if(g_br_ex==0) return -1; // no tgraph
+  }
+  g_br[mode]->GetPoint(point,ex,br);
+
+  if(NucDeEx::Utils::fVerbose>1){
+    std::cout << "GetBrExTGraph(): nearest_point = " << point << ",  ex at the point = " << ex
+      << ", diff_Ex = " << abs(ex-ex_t) << ", diff_ex(previous) = " << diff_ex << std::endl;
+
+  }
+  if(ex==0 && point==0) return 0; // g.s.
+  return 1;
+}
+
+
+/////////////////////////////////////////////
+bool NucDeExDeexcitationTALYS::DaughterExPoint(double *d_Ex, int *d_point)
+/////////////////////////////////////////////
+{
+  double ex=0, br=0;
+  double Br_sum=0;
+  for(int p=0;p<g_br_ex->GetN();p++){
+    g_br_ex->GetPoint(p,ex,br);
+    Br_sum += br;
+  }
+  double Br_integ=0;
+  double random = NucDeEx::Random::random();
+  int point=0;
+  for(point=0;point<g_br_ex->GetN();point++){
+    g_br_ex->GetPoint(point,ex,br);
+    br /= Br_sum; // Normalize Br just in case.
+    Br_integ += br;
+    if(Br_integ>random) break;
+  }
+  if(NucDeEx::Utils::fVerbose>1){
+    std::cout << "DaughterExPoint: Random = " << random << " : ex = " << ex
+         << ",   point = " << point << std::endl;
+  }
+
+  *d_Ex=ex;
+  *d_point=point;
+
+  return 1;
+}
+
+
+/////////////////////////////////////////////
+void NucDeExDeexcitationTALYS::DeleteTGraphs()
+/////////////////////////////////////////////
+{
+  for(int p=0;p<NucDeEx::num_particle;p++){
+    delete g_br[p];
+    g_br[p]=0;
+  }
+  delete g_br_ex;
+  g_br_ex=0;
+}

--- a/src/NucDeExEventInfo.cc
+++ b/src/NucDeExEventInfo.cc
@@ -14,20 +14,18 @@
 
 /////////////////////////////////////////////
 NucDeExEventInfo::NucDeExEventInfo(): eventID(0), fStatus(0), fShell(0), Zt(0), Nt(0), Z(0), N(0),
-                                      Ex(0), ParticleVector(0)
+                                      Ex(0)
 /////////////////////////////////////////////
 {
   Pinit.SetXYZ(0,0,0);
+  ParticleVector.clear();
 }
 
 /////////////////////////////////////////////
 NucDeExEventInfo::~NucDeExEventInfo()
 /////////////////////////////////////////////
 {
-  if(ParticleVector!=0){
-    ParticleVector->clear();
-    delete ParticleVector;
-  }
+  ;
 }
 /////////////////////////////////////////////
 void NucDeExEventInfo::InitParameters()
@@ -36,9 +34,6 @@ void NucDeExEventInfo::InitParameters()
   eventID = fStatus = fShell =0;
   Zt = Nt = Z = N = 0;
   Ex = 0.;
-  if(ParticleVector!=0){
-    ParticleVector->clear();
-    delete ParticleVector;
-  }
-  ParticleVector = new std::vector<NucDeExParticle>;
+  ParticleVector.clear();
+  std::vector<NucDeExParticle>().swap(ParticleVector);
 }

--- a/src/NucDeExEventInfo.cc
+++ b/src/NucDeExEventInfo.cc
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+#include <stdio.h>
+#include <string>
+#include <string.h>
+#include <cstdlib>
+#include <algorithm>
+#include <vector>
+
+#include "NucDeExUtils.hh"
+#include "NucDeExEventInfo.hh"
+
+/////////////////////////////////////////////
+NucDeExEventInfo::NucDeExEventInfo(): eventID(0), fStatus(0), fShell(0), Zt(0), Nt(0), Z(0), N(0),
+                                      Ex(0), ParticleVector(0)
+/////////////////////////////////////////////
+{
+  Pinit.SetXYZ(0,0,0);
+}
+
+/////////////////////////////////////////////
+NucDeExEventInfo::~NucDeExEventInfo()
+/////////////////////////////////////////////
+{
+  if(ParticleVector!=0){
+    ParticleVector->clear();
+    delete ParticleVector;
+  }
+}
+/////////////////////////////////////////////
+void NucDeExEventInfo::InitParameters()
+/////////////////////////////////////////////
+{
+  eventID = fStatus = fShell =0;
+  Zt = Nt = Z = N = 0;
+  Ex = 0.;
+  if(ParticleVector!=0){
+    ParticleVector->clear();
+    delete ParticleVector;
+  }
+  ParticleVector = new std::vector<NucDeExParticle>;
+}

--- a/src/NucDeExEventInfo.cc
+++ b/src/NucDeExEventInfo.cc
@@ -9,12 +9,11 @@
 #include <algorithm>
 #include <vector>
 
-#include "NucDeExUtils.hh"
 #include "NucDeExEventInfo.hh"
 
 /////////////////////////////////////////////
-NucDeExEventInfo::NucDeExEventInfo(): eventID(0), fStatus(0), fShell(0), Zt(0), Nt(0), Z(0), N(0),
-                                      Ex(0)
+NucDeExEventInfo::NucDeExEventInfo(): EventID(0), fStatus(0), fShell(0),
+                                      Zt(0), Nt(0), Z(0), N(0), Ex(0)
 /////////////////////////////////////////////
 {
   Pinit.SetXYZ(0,0,0);
@@ -31,7 +30,7 @@ NucDeExEventInfo::~NucDeExEventInfo()
 void NucDeExEventInfo::InitParameters()
 /////////////////////////////////////////////
 {
-  eventID = fStatus = fShell =0;
+  EventID = fStatus = fShell =0;
   Zt = Nt = Z = N = 0;
   Ex = 0.;
   ParticleVector.clear();

--- a/src/NucDeExNucleusTable.cc
+++ b/src/NucDeExNucleusTable.cc
@@ -29,7 +29,8 @@ bool NucDeExNucleusTable::ReadTables(const bool init_flag)
   std::ifstream ifs(filename1);
   if(!ifs.is_open()){
     std::cerr << "ERROR : Cannot open " << filename1 << std::endl;
-    return 0;
+    //return 0;
+    exit(1);
   }else{
     if(NucDeEx::Utils::fVerbose>0) std::cout << "Read: " << filename1 << std::endl;
   }

--- a/src/NucDeExNucleusTable.cc
+++ b/src/NucDeExNucleusTable.cc
@@ -17,7 +17,7 @@ NucDeExNucleusTable::NucDeExNucleusTable()
 ///////////////
 {
   num_of_nuc=-1;
-  NucDeExUtils::SetPATH();
+  NucDeEx::Utils::SetPATH();
 }
 
 ///////////////
@@ -25,13 +25,13 @@ bool NucDeExNucleusTable::ReadTables(const bool init_flag)
 ///////////////
 {
   // --- Read nucleus / separation energy tables ---//
-  std::string filename1= NucDeExUtils::GetPATH()+(std::string)"/tables/nucleus/nucleus.txt";
+  std::string filename1= NucDeEx::Utils::NUCDEEX_ROOT+(std::string)"/tables/nucleus/nucleus.txt";
   std::ifstream ifs(filename1);
   if(!ifs.is_open()){
     std::cerr << "ERROR : Cannot open " << filename1 << std::endl;
     return 0;
   }else{
-    if(NucDeExUtils::GetVerbose()>0) std::cout << "Read: " << filename1 << std::endl;
+    if(NucDeEx::Utils::fVerbose>0) std::cout << "Read: " << filename1 << std::endl;
   }
 // at first get num of nucleus in the table
   int index=0;
@@ -68,7 +68,7 @@ bool NucDeExNucleusTable::ReadTables(const bool init_flag)
     _nucleus[index].maxlevelsbin = maxlevelsbin;
 
     // read separation energy table
-    std::string filename2= NucDeExUtils::GetPATH()
+    std::string filename2= NucDeEx::Utils::NUCDEEX_ROOT
                       + (std::string)"/tables/separation_energy/separation_energy_"
                       + (std::string)Name
                       + (std::string)".txt";
@@ -76,13 +76,13 @@ bool NucDeExNucleusTable::ReadTables(const bool init_flag)
     if(!ifs2.is_open()){
       std::cerr << "Warning: We do not have separation energy file for " << Name << std::endl;
     }else{
-      if(NucDeExUtils::GetVerbose()>0) std::cout << "Read: " << filename2 << std::endl;
+      if(NucDeEx::Utils::fVerbose>0) std::cout << "Read: " << filename2 << std::endl;
       _nucleus[index].flag_s = 1;
       int particle_index=0;
       while(ifs2.getline(buf,sizeof(buf))){
         if(buf[0]=='#') continue;
         std::istringstream(buf) >> _nucleus[index].S[particle_index];
-        if(NucDeExUtils::GetVerbose()>0) std::cout << "SE: " << NucDeEx::particle_name[particle_index].substr(0,1) << " = " << _nucleus[index].S[particle_index] << std::endl;
+        if(NucDeEx::Utils::fVerbose>0) std::cout << "SE: " << NucDeEx::particle_name[particle_index].substr(0,1) << " = " << _nucleus[index].S[particle_index] << std::endl;
         particle_index++;
       }
       ifs2.close();
@@ -138,7 +138,7 @@ int NucDeExNucleusTable::getID(const char* name)
   if(_p_id!=_nucleus_id.end()){
     return (int) ((_p_id->second));
   }else{
-    if(NucDeExUtils::GetVerbose()>0) std::cerr << "Warning @ NucDeExNucleusTable: Cannot find such nucleus " << name << std::endl;
+    if(NucDeEx::Utils::fVerbose>0) std::cerr << "Warning @ NucDeExNucleusTable: Cannot find such nucleus " << name << std::endl;
     return -1;
   }
 }

--- a/src/NucDeExNucleusTable.cc
+++ b/src/NucDeExNucleusTable.cc
@@ -18,14 +18,14 @@ NucDeExNucleusTable::NucDeExNucleusTable()
 {
   flag_read=0;
   num_of_nuc=-1;
-  NucDeEx::Utils::SetPATH();
+  //NucDeEx::Utils::SetPATH();
 }
 
 ///////////////
 bool NucDeExNucleusTable::ReadTables(const bool init_flag)
 ///////////////
 {
-  if(flag_read) return 0;
+  if(flag_read) return 0; // already read -> END
 
   // --- Read nucleus / separation energy tables ---//
   std::string filename1= NucDeEx::Utils::NUCDEEX_ROOT+(std::string)"/tables/nucleus/nucleus.txt";

--- a/src/NucDeExNucleusTable.cc
+++ b/src/NucDeExNucleusTable.cc
@@ -8,60 +8,32 @@
 #include <cstdlib>
 
 #include "NucDeExConsts.hh"
+#include "NucDeExUtils.hh"
 #include "NucDeExNucleusTable.hh"
 
-#ifdef INCL_DEEXCITATION_NUCDEEX
-#include "G4INCLConfig.hh"
-#endif
 
 ///////////////
 NucDeExNucleusTable::NucDeExNucleusTable()
 ///////////////
 {
-  verbose=1;
   num_of_nuc=-1;
-  const char* env = getenv("NUCDEEX_ROOT");
-#ifdef WITH_NEUT
-  env = getenv("NEUT_ROOT");
-#endif
-  if(env!=NULL){
-    PATH_NucDeEx_table = env + (std::string)"/tables";
-#ifdef WITH_NEUT
-    PATH_NucDeEx_table = env + (std::string)"/../../src/nucdeex/nucdeex/tables";
-#endif
-  }else{
-    std::cerr << "PATH to nucleus table is not specified" << std::endl;
-    exit(1);
-  }
+  NucDeExUtils::SetPATH();
 }
-
-#ifdef INCL_DEEXCITATION_NUCDEEX
-///////////////
-NucDeExNucleusTable::NucDeExNucleusTable(G4INCL::Config *config)
-///////////////
-{
-  verbose=1;
-  num_of_nuc=-1;
-  PATH_NucDeEx_table = config->getNucDeExDataFilePath() + "/tables";
-  //std::cout << PATH_NucDeEx_table.c_str() << std::endl;
-}
-#endif
 
 ///////////////
 bool NucDeExNucleusTable::ReadTables(const bool init_flag)
 ///////////////
 {
   // --- Read nucleus / separation energy tables ---//
-  std::string filename1= PATH_NucDeEx_table+(std::string)"/nucleus/nucleus.txt";
+  std::string filename1= NucDeExUtils::GetPATH()+(std::string)"/tables/nucleus/nucleus.txt";
   std::ifstream ifs(filename1);
   if(!ifs.is_open()){
     std::cerr << "ERROR : Cannot open " << filename1 << std::endl;
     return 0;
   }else{
-    if(verbose>0) std::cout << "Read: " << filename1 << std::endl;
+    if(NucDeExUtils::GetVerbose()>0) std::cout << "Read: " << filename1 << std::endl;
   }
-
-  // at first get num of nucleus in the table
+// at first get num of nucleus in the table
   int index=0;
   char buf[500];
   while(ifs.getline(buf,sizeof(buf))){
@@ -96,21 +68,21 @@ bool NucDeExNucleusTable::ReadTables(const bool init_flag)
     _nucleus[index].maxlevelsbin = maxlevelsbin;
 
     // read separation energy table
-    std::string filename2= PATH_NucDeEx_table
-                      + (std::string)"/separation_energy/separation_energy_"
+    std::string filename2= NucDeExUtils::GetPATH()
+                      + (std::string)"/tables/separation_energy/separation_energy_"
                       + (std::string)Name
                       + (std::string)".txt";
     std::ifstream ifs2(filename2);
     if(!ifs2.is_open()){
       std::cerr << "Warning: We do not have separation energy file for " << Name << std::endl;
     }else{
-      if(verbose>0) std::cout << "Read: " << filename2 << std::endl;
+      if(NucDeExUtils::GetVerbose()>0) std::cout << "Read: " << filename2 << std::endl;
       _nucleus[index].flag_s = 1;
       int particle_index=0;
       while(ifs2.getline(buf,sizeof(buf))){
         if(buf[0]=='#') continue;
         std::istringstream(buf) >> _nucleus[index].S[particle_index];
-        if(verbose>0) std::cout << "SE: " << NucDeEx::particle_name[particle_index].substr(0,1) << " = " << _nucleus[index].S[particle_index] << std::endl;
+        if(NucDeExUtils::GetVerbose()>0) std::cout << "SE: " << NucDeEx::particle_name[particle_index].substr(0,1) << " = " << _nucleus[index].S[particle_index] << std::endl;
         particle_index++;
       }
       ifs2.close();
@@ -166,7 +138,7 @@ int NucDeExNucleusTable::getID(const char* name)
   if(_p_id!=_nucleus_id.end()){
     return (int) ((_p_id->second));
   }else{
-    if(verbose>0) std::cerr << "Warning @ NucDeExNucleusTable: Cannot find such nucleus " << name << std::endl;
+    if(NucDeExUtils::GetVerbose()>0) std::cerr << "Warning @ NucDeExNucleusTable: Cannot find such nucleus " << name << std::endl;
     return -1;
   }
 }

--- a/src/NucDeExNucleusTable.cc
+++ b/src/NucDeExNucleusTable.cc
@@ -16,6 +16,7 @@
 NucDeExNucleusTable::NucDeExNucleusTable()
 ///////////////
 {
+  flag_read=0;
   num_of_nuc=-1;
   NucDeEx::Utils::SetPATH();
 }
@@ -24,6 +25,8 @@ NucDeExNucleusTable::NucDeExNucleusTable()
 bool NucDeExNucleusTable::ReadTables(const bool init_flag)
 ///////////////
 {
+  if(flag_read) return 0;
+
   // --- Read nucleus / separation energy tables ---//
   std::string filename1= NucDeEx::Utils::NUCDEEX_ROOT+(std::string)"/tables/nucleus/nucleus.txt";
   std::ifstream ifs(filename1);
@@ -91,6 +94,7 @@ bool NucDeExNucleusTable::ReadTables(const bool init_flag)
     index++;
   }
   ifs.close();
+  flag_read=1;
 
   return true;
 }

--- a/src/NucDeExParticle.cc
+++ b/src/NucDeExParticle.cc
@@ -68,7 +68,7 @@ void NucDeExParticle::Boost(const double totalE_parent,const TVector3& mom_paren
     cerr << "Inputed Mass = " << _mass << endl;
     abort();
   }
-  if(NucDeExUtils::GetVerbose()>1){
+  if(NucDeEx::Utils::fVerbose>1){
     cout << "Bef boost: ";
     lv.Print();
   }
@@ -77,7 +77,7 @@ void NucDeExParticle::Boost(const double totalE_parent,const TVector3& mom_paren
   lv.Boost(beta);
 
   _momentum = lv.Vect(); // save new vectors after boost
-  if(NucDeExUtils::GetVerbose()>1){
+  if(NucDeEx::Utils::fVerbose>1){
     cout << "Aft boost: ";
     lv.Print();
     _momentum.Print();

--- a/src/NucDeExParticle.cc
+++ b/src/NucDeExParticle.cc
@@ -16,6 +16,9 @@ NucDeExParticle::NucDeExParticle()
   _PDG=0;
   _mass=0;
   _momentum.SetXYZ(0,0,0);
+  _name="";
+  _flag=0;
+  _Ex=0;
 }
 
 ///////////////

--- a/src/NucDeExParticle.cc
+++ b/src/NucDeExParticle.cc
@@ -1,4 +1,5 @@
 #include "NucDeExParticle.hh"
+#include "NucDeExUtils.hh"
 
 #include <fstream>
 #include <sstream>
@@ -15,12 +16,11 @@ NucDeExParticle::NucDeExParticle()
   _PDG=0;
   _mass=0;
   _momentum.SetXYZ(0,0,0);
-  verbose=0;
 }
 
 ///////////////
 NucDeExParticle::NucDeExParticle(const int PDG, const double mass, const TVector3& mom, 
-                   const string name, const bool flag, const double Ex, const int v)
+                   const string name, const bool flag, const double Ex)
 ///////////////
 {
   _PDG=PDG;
@@ -29,7 +29,6 @@ NucDeExParticle::NucDeExParticle(const int PDG, const double mass, const TVector
   _name=name;
   _flag=flag;
   _Ex=Ex;
-  verbose=v;
 }
 
 
@@ -69,7 +68,7 @@ void NucDeExParticle::Boost(const double totalE_parent,const TVector3& mom_paren
     cerr << "Inputed Mass = " << _mass << endl;
     abort();
   }
-  if(verbose>1){
+  if(NucDeExUtils::GetVerbose()>1){
     cout << "Bef boost: ";
     lv.Print();
   }
@@ -78,7 +77,7 @@ void NucDeExParticle::Boost(const double totalE_parent,const TVector3& mom_paren
   lv.Boost(beta);
 
   _momentum = lv.Vect(); // save new vectors after boost
-  if(verbose>1){
+  if(NucDeExUtils::GetVerbose()>1){
     cout << "Aft boost: ";
     lv.Print();
     _momentum.Print();

--- a/src/NucDeExRandom.cc
+++ b/src/NucDeExRandom.cc
@@ -1,0 +1,7 @@
+#include "NucDeExRandom.hh"
+
+namespace NucDeEx{
+  namespace Random{
+    random(){ return rndm->Rndm(); };
+  }
+}

--- a/src/NucDeExRandom.cc
+++ b/src/NucDeExRandom.cc
@@ -2,6 +2,8 @@
 
 namespace NucDeEx{
   namespace Random{
-    random(){ return rndm->Rndm(); };
+    TRandom3 rndm(1);
+    double random(){ return rndm.Rndm(); };
+    void SetSeed(int s){ rndm.SetSeed(s); };
   }
 }

--- a/src/NucDeExUtils.cc
+++ b/src/NucDeExUtils.cc
@@ -5,9 +5,27 @@
 
 namespace NucDeEx{
   namespace Utils{
+    // --- Define & initialize --- //
     int fVerbose=0;
     std::string NUCDEEX_ROOT="";
     NucDeExNucleusTable* NucleusTable=NULL;
+    TDatabasePDG* fTDatabasePDG=NULL;
+    TGeoManager* fTGeoManager=NULL;
+    TGeoElementTable* fTGeoElementTable=NULL;
+
+    void Init()
+    {
+      if(NucleusTable==NULL){
+         NucleusTable = new NucDeExNucleusTable();
+      }
+      if(fTDatabasePDG==NULL){
+        fTDatabasePDG = new TDatabasePDG();
+      }
+      if(fTGeoManager==NULL){
+        fTGeoManager = new TGeoManager("NucDeEx","NucDeEx");
+        fTGeoElementTable = fTGeoManager->GetElementTable();
+      }
+    }
 
     void SetPATH()
     {

--- a/src/NucDeExUtils.cc
+++ b/src/NucDeExUtils.cc
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <string>
+
+#include "NucDeExUtils.hh"
+
+int NucDeExUtils::fVerbose=0;
+int NucDeExUtils::fSeed=0;
+std::string NucDeExUtils::NUCDEEX_ROOT="";
+
+/////////////////////////////////////////////
+void NucDeExUtils::SetPATH()
+/////////////////////////////////////////////
+{
+  if(NUCDEEX_ROOT.length()>0) return;
+  const char* env = getenv("NUCDEEX_ROOT");
+  NUCDEEX_ROOT = env;
+#ifdef WITH_NEUT
+  env = getenv("NEUT_ROOT");
+  NUCDEEX_ROOT = env + (std::string)"/../../src/nucdeex/nucdeex";
+#endif
+  if(env==NULL){
+    std::cerr << "PATH to nucleus table is not specified" << std::endl;
+    exit(1);
+  }
+  std::cout << "NUCDEEX_ROOT: " << NUCDEEX_ROOT.c_str() << std::endl;
+}
+
+#ifdef INCL_DEEXCITATION_NUCDEEX
+/////////////////////////////////////////////
+void NucDeExUtils::SetPATH(G4INCL::Config* config)
+/////////////////////////////////////////////
+{
+  if(NUCDEEX_ROOT.length()>0) return;
+  NUCDEEX_ROOT = config->getNucDeExDataFilePath();
+  std::cout << "NUCDEEX_ROOT: " << NUCDEEX_ROOT.c_str() << std::endl;
+}
+#endif

--- a/src/NucDeExUtils.cc
+++ b/src/NucDeExUtils.cc
@@ -3,35 +3,35 @@
 
 #include "NucDeExUtils.hh"
 
-int NucDeExUtils::fVerbose=0;
-int NucDeExUtils::fSeed=0;
-std::string NucDeExUtils::NUCDEEX_ROOT="";
+namespace NucDeEx{
+  namespace Utils{
+    int fVerbose=0;
+    std::string NUCDEEX_ROOT="";
 
-/////////////////////////////////////////////
-void NucDeExUtils::SetPATH()
-/////////////////////////////////////////////
-{
-  if(NUCDEEX_ROOT.length()>0) return;
-  const char* env = getenv("NUCDEEX_ROOT");
-  NUCDEEX_ROOT = env;
+
+    void SetPATH()
+    {
+      if(NUCDEEX_ROOT.length()>0) return;
+      const char* env = getenv("NUCDEEX_ROOT");
+      NUCDEEX_ROOT = env;
 #ifdef WITH_NEUT
-  env = getenv("NEUT_ROOT");
-  NUCDEEX_ROOT = env + (std::string)"/../../src/nucdeex/nucdeex";
+      env = getenv("NEUT_ROOT");
+      NUCDEEX_ROOT = env + (std::string)"/../../src/nucdeex/nucdeex";
 #endif
-  if(env==NULL){
-    std::cerr << "PATH to nucleus table is not specified" << std::endl;
-    exit(1);
-  }
-  std::cout << "NUCDEEX_ROOT: " << NUCDEEX_ROOT.c_str() << std::endl;
-}
+      if(env==NULL){
+        std::cerr << "PATH to nucleus table is not specified" << std::endl;
+        exit(1);
+      }
+      std::cout << "NUCDEEX_ROOT: " << NUCDEEX_ROOT.c_str() << std::endl;
+    }
 
 #ifdef INCL_DEEXCITATION_NUCDEEX
-/////////////////////////////////////////////
-void NucDeExUtils::SetPATH(G4INCL::Config* config)
-/////////////////////////////////////////////
-{
-  if(NUCDEEX_ROOT.length()>0) return;
-  NUCDEEX_ROOT = config->getNucDeExDataFilePath();
-  std::cout << "NUCDEEX_ROOT: " << NUCDEEX_ROOT.c_str() << std::endl;
-}
+    void SetPATH(G4INCL::Config* config)
+    {
+      if(NUCDEEX_ROOT.length()>0) return;
+      NUCDEEX_ROOT = config->getNucDeExDataFilePath();
+      std::cout << "NUCDEEX_ROOT: " << NUCDEEX_ROOT.c_str() << std::endl;
+    }
 #endif
+    }
+}

--- a/src/NucDeExUtils.cc
+++ b/src/NucDeExUtils.cc
@@ -7,6 +7,7 @@ namespace NucDeEx{
   namespace Utils{
     int fVerbose=0;
     std::string NUCDEEX_ROOT="";
+    NucDeExNucleusTable* NucleusTable=NULL;
 
     void SetPATH()
     {
@@ -32,5 +33,5 @@ namespace NucDeEx{
       std::cout << "NUCDEEX_ROOT: " << NUCDEEX_ROOT.c_str() << std::endl;
     }
 #endif
-    }
+  }
 }

--- a/src/NucDeExUtils.cc
+++ b/src/NucDeExUtils.cc
@@ -8,7 +8,6 @@ namespace NucDeEx{
     int fVerbose=0;
     std::string NUCDEEX_ROOT="";
 
-
     void SetPATH()
     {
       if(NUCDEEX_ROOT.length()>0) return;

--- a/src/ReadTALYS.cc
+++ b/src/ReadTALYS.cc
@@ -70,7 +70,7 @@ bool ReadTALYS::Read()
     int find_discrete = st.find(keyword_discrete->c_str());
     if(find_discrete != std::string::npos){
       flag_mode=2;
-      if(NucDeExUtils::GetVerbose()>0){
+      if(NucDeEx::Utils::fVerbose>0){
         std::cout << "### Discrete mode ###" << std::endl;
       }
       st = st.substr(find_discrete+keyword_discrete->length());
@@ -84,7 +84,7 @@ bool ReadTALYS::Read()
       st = st.substr(find_N+keyword_N->length());
       std::istringstream(st) >> n; // obtain n
       nuc = _nucleus_table->GetNucleusPtr(z, n);
-      if(NucDeExUtils::GetVerbose()>0){
+      if(NucDeEx::Utils::fVerbose>0){
         std::cout << nuc->name << " " << z << " " << n << std::endl;
       }
     }else if(flag_mode==2){// discrete mode
@@ -105,7 +105,7 @@ bool ReadTALYS::Read()
         float tmp_br; // br (%)
         std::istringstream(st) >> d_bin_daughter >> tmp_br;
         nuc->level_br[d_bin][d_bin_daughter] = tmp_br;
-        if(NucDeExUtils::GetVerbose()>0){
+        if(NucDeEx::Utils::fVerbose>0){
           std::cout << d_bin << " ---> " << d_bin_daughter  << " : " << nuc->level_br[d_bin][d_bin_daughter] << std::endl;
         }
       }
@@ -115,7 +115,7 @@ bool ReadTALYS::Read()
     // ->  get total population
     int find_population = st.find(keyword_population->c_str());
     if(find_population != std::string::npos){
-      if(NucDeExUtils::GetVerbose()>0 && flag_mode!=0){
+      if(NucDeEx::Utils::fVerbose>0 && flag_mode!=0){
         std::cout << "### Population mode ###" << std::endl;
       }
       flag_mode=0;
@@ -149,7 +149,7 @@ bool ReadTALYS::Read()
 
         // Fill params
         nuc->sum_pop = total_pop;
-        if(NucDeExUtils::GetVerbose()>0){
+        if(NucDeEx::Utils::fVerbose>0){
           std::cout <<  "total population: " << nuc->name << " " << nuc->Z << " " << nuc->N << " " 
                << nuc->A << " " << nuc->sum_pop << std::endl;
         }
@@ -169,7 +169,7 @@ bool ReadTALYS::Read()
         st = st.substr(find_before_decay+keyword_before_decay->length());
         std::istringstream(st) >> pop;
         nuc->total_pop[parity_array] = pop;
-        if(NucDeExUtils::GetVerbose()>0){
+        if(NucDeEx::Utils::fVerbose>0){
           std::cout <<  "parity dependent population: " << nuc->name << " (" << nuc->Z << "," << nuc->N 
                << "," << nuc->A << ") " << nuc->total_pop[parity_array] << std::endl;
         }
@@ -197,14 +197,14 @@ bool ReadTALYS::Read()
             nuc->Ex_bin[parity_array] = bin+1;
             nuc->Ex[parity_array][bin]=Ex;
             nuc->pop[parity_array][bin]=pop_p;
-            if(NucDeExUtils::GetVerbose()>1){
+            if(NucDeEx::Utils::fVerbose>1){
               std::cout << "Parity(" << parity_array << ")" << ": excitation & pop: " << nuc->name << " " << nuc->Ex_bin[parity_array] 
                    << " " << std::setw(9) << nuc->Ex[parity_array][bin] << " " << std::setw(9) << nuc->pop[parity_array][bin]  << std::endl;
             }
           }
         }
       }else if (find_decay!=std::string::npos){ // decay info was found
-        //if(NucDeExUtils::GetVerbose()>0){
+        //if(NucDeEx::Utils::fVerbose>0){
         //  std::cout << "### Decay mode ###" << std::endl;
         //}
         flag_mode=1;
@@ -240,7 +240,7 @@ bool ReadTALYS::Read()
         st = st.substr(find_total+keyword_total->length());
         std::istringstream(st) >> pop_total_decay; // obtain pop for the decay
             // this parameter wil be sum of transition pop for both parity (negative + positive)
-        if(NucDeExUtils::GetVerbose()>1){
+        if(NucDeEx::Utils::fVerbose>1){
           std::cout << "Total pop (decay): " << pop_total_decay << std::endl;
         }
       }else if(flag_mode==1){ // not decay info, but decay mode -> decay pop info

--- a/src/ReadTALYS.cc
+++ b/src/ReadTALYS.cc
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <algorithm>
 
+#include "NucDeExUtils.hh"
 #include "NucDeExNucleus.hh"
 #include "ReadTALYS.hh"
 
@@ -18,7 +19,6 @@ ReadTALYS::ReadTALYS(const char* filename, NucDeExNucleusTable* nuc)
   _filename = filename;
   _nucleus_table = nuc;
   os = new std::ostringstream;
-  _verbose=0;
 }
 
 ///////////////////////////
@@ -70,7 +70,7 @@ bool ReadTALYS::Read()
     int find_discrete = st.find(keyword_discrete->c_str());
     if(find_discrete != std::string::npos){
       flag_mode=2;
-      if(_verbose>0){
+      if(NucDeExUtils::GetVerbose()>0){
         std::cout << "### Discrete mode ###" << std::endl;
       }
       st = st.substr(find_discrete+keyword_discrete->length());
@@ -84,7 +84,7 @@ bool ReadTALYS::Read()
       st = st.substr(find_N+keyword_N->length());
       std::istringstream(st) >> n; // obtain n
       nuc = _nucleus_table->GetNucleusPtr(z, n);
-      if(_verbose>0){
+      if(NucDeExUtils::GetVerbose()>0){
         std::cout << nuc->name << " " << z << " " << n << std::endl;
       }
     }else if(flag_mode==2){// discrete mode
@@ -105,7 +105,7 @@ bool ReadTALYS::Read()
         float tmp_br; // br (%)
         std::istringstream(st) >> d_bin_daughter >> tmp_br;
         nuc->level_br[d_bin][d_bin_daughter] = tmp_br;
-        if(_verbose>0){
+        if(NucDeExUtils::GetVerbose()>0){
           std::cout << d_bin << " ---> " << d_bin_daughter  << " : " << nuc->level_br[d_bin][d_bin_daughter] << std::endl;
         }
       }
@@ -115,7 +115,7 @@ bool ReadTALYS::Read()
     // ->  get total population
     int find_population = st.find(keyword_population->c_str());
     if(find_population != std::string::npos){
-      if(_verbose>0 && flag_mode!=0){
+      if(NucDeExUtils::GetVerbose()>0 && flag_mode!=0){
         std::cout << "### Population mode ###" << std::endl;
       }
       flag_mode=0;
@@ -149,7 +149,7 @@ bool ReadTALYS::Read()
 
         // Fill params
         nuc->sum_pop = total_pop;
-        if(_verbose>0){
+        if(NucDeExUtils::GetVerbose()>0){
           std::cout <<  "total population: " << nuc->name << " " << nuc->Z << " " << nuc->N << " " 
                << nuc->A << " " << nuc->sum_pop << std::endl;
         }
@@ -169,7 +169,7 @@ bool ReadTALYS::Read()
         st = st.substr(find_before_decay+keyword_before_decay->length());
         std::istringstream(st) >> pop;
         nuc->total_pop[parity_array] = pop;
-        if(_verbose>0){
+        if(NucDeExUtils::GetVerbose()>0){
           std::cout <<  "parity dependent population: " << nuc->name << " (" << nuc->Z << "," << nuc->N 
                << "," << nuc->A << ") " << nuc->total_pop[parity_array] << std::endl;
         }
@@ -197,14 +197,14 @@ bool ReadTALYS::Read()
             nuc->Ex_bin[parity_array] = bin+1;
             nuc->Ex[parity_array][bin]=Ex;
             nuc->pop[parity_array][bin]=pop_p;
-            if(_verbose>1){
+            if(NucDeExUtils::GetVerbose()>1){
               std::cout << "Parity(" << parity_array << ")" << ": excitation & pop: " << nuc->name << " " << nuc->Ex_bin[parity_array] 
                    << " " << std::setw(9) << nuc->Ex[parity_array][bin] << " " << std::setw(9) << nuc->pop[parity_array][bin]  << std::endl;
             }
           }
         }
       }else if (find_decay!=std::string::npos){ // decay info was found
-        //if(_verbose>0){
+        //if(NucDeExUtils::GetVerbose()>0){
         //  std::cout << "### Decay mode ###" << std::endl;
         //}
         flag_mode=1;
@@ -240,7 +240,7 @@ bool ReadTALYS::Read()
         st = st.substr(find_total+keyword_total->length());
         std::istringstream(st) >> pop_total_decay; // obtain pop for the decay
             // this parameter wil be sum of transition pop for both parity (negative + positive)
-        if(_verbose>1){
+        if(NucDeExUtils::GetVerbose()>1){
           std::cout << "Total pop (decay): " << pop_total_decay << std::endl;
         }
       }else if(flag_mode==1){ // not decay info, but decay mode -> decay pop info


### PR DESCRIPTION
The outputs are identical to those of v1.3.

UI
- All output is collected in `NucDeExEventInfo`
- Prepare new namespace `NucDeEx::Utils` that contains verbosity, pointer to NucDeExNucleusTable, and PATH to NUCDEEX_ROOT (as a string).
- Add new namespace `NucDeEx::Random` that handles random generator.

Code structure
- Functions in `NucDeExDeexcitation` are divided into several classes
  - `NucDeExDeexcitationBase`: Base (parent) class
  - `NucDeExDeexcitation`: Master class
  - `NucDeExDeexcitationTALYS`: Simulation with TALYS
  - `NucDeExDeexcitationPhole`: Simulation for p-hole (w/o TALYS)

Minor bug fix
- Resolve an issue that saves an improper shell flag.
- Resolve improper escape of negative excitation energy
  - This bug slightly biased gamma emission probability from p-hole states of 11C*/11B*
  - This does not affect other nuclei.