### PR TITLE
Optimize operation of ROOT file and TGraph

### DIFF
--- a/include/NucDeExDeexcitationTALYS.hh
+++ b/include/NucDeExDeexcitationTALYS.hh
@@ -38,16 +38,26 @@ class NucDeExDeexcitationTALYS: public NucDeExDeexcitationBase{
   int DecayMode(const double Ex);
 
   // --- ROOT related methods & members --- //
-  bool OpenROOT(const int Zt,const int Nt, const int Z, const int N);
-  bool GetBrTGraph(const std::string st);
+  void GetAllTGraph();
+  std::map<std::string, int> map_root; 
+    // store nucleus of root file: nucleus name -> [file]
+  std::map<std::string, int> map_nucleus[NucDeEx::bins]; 
+    // store nucleus of tgraph (target nucleus): nucleus name -> [nucleus]
+  std::map<std::string, int> :: iterator it;
+  int getRootID(const char* name);
+  int getNucleusID(int i, const char* name);
+  int fRootID, fNucleusID, fPoint;
+    // [file], [nucleus], [Exbin]
+    // use "decay_mdoe for [particle]
+
   int  GetBrExTGraph(const std::string st, const double ex_t, const int mode); 
   bool DaughterExPoint(double *d_Ex, int *d_point); //call by pointer
-    // The nearest TGraph point will be returned
-  void DeleteTGraphs();
 
-  TFile* rootf;
-  TGraph* g_br[NucDeEx::num_particle];
-  TGraph* g_br_ex;
+  TGraph* g_br_all[NucDeEx::bins][NucDeEx::bins][NucDeEx::num_particle]; 
+    // [file][nucleus][particle]
+  TGraph* g_br_ex_all[NucDeEx::bins][NucDeEx::bins][NucDeEx::num_particle][NucDeEx::bins];
+    // [file][nucleus][particle][Exbin]
+
 
   int ldmodel;
   bool parity_optmodall;


### PR DESCRIPTION
This branch contains the optimization of the ROOT file and TGraph operation.
In v2.1, TGraphs that contain branching ratios are read from the ROOT file event by event, causing the increase I/O amount and memory leakage related to TGraph operation.
In this branch, all ROOT files and TGraph are read at the beginning of the simulation.
The initialization takes a longer time, ~1.5 min. but this modification saves memory and CPU usage dramatically.
The memory usage was almost proportional to the number of generated events (e.g., 12 GB was used with 1e6 ev of 11B*), but it is almost independent in this branch (~0.8GB regardless of the number of events).

As a result of the benchmark of event generation, 1e5 events 11B*,:
v2.1: ~32 min. ~1.2 GB
This branch: ~ 2min. ~0.8GB