### PR TITLE
Subtract electron mass from isotopic mass to get nuclede mass

### DIFF
--- a/src/NucDeExDeexcitationBase.cc
+++ b/src/NucDeExDeexcitationBase.cc
@@ -200,7 +200,12 @@ double NucDeExDeexcitationBase::ElementMassInMeV(const TGeoElementRN* ele)
   if(ele==0) return -1; // no profile can be found.
   double mass = ele->MassNo()*NucDeEx::amu_c2
                    + ele->MassEx(); // (MeV)
-  double mass_amu = mass/NucDeEx::amu_c2;
+  // This mass should be nuclei mass, not istoopic mass.
+  // We should subtract electron masss.
+  mass -= ele->AtomicNo()*NucDeEx::Utils::fTDatabasePDG->GetParticle(11)->Mass()*1e3;// GeV2MeV
+  cout << NucDeEx::Utils::fTDatabasePDG->GetParticle(11)->Mass()*1e3 << endl;
+
+  double mass_amu = mass/NucDeEx::amu_c2; // MeV to AMU
   if(NucDeEx::Utils::fVerbose>1){
     std::cout << "mass (MeV) = " << mass 
          << "    (amu) = " << mass_amu << std::endl;

--- a/src/NucDeExDeexcitationBase.cc
+++ b/src/NucDeExDeexcitationBase.cc
@@ -206,7 +206,7 @@ double NucDeExDeexcitationBase::ElementMassInMeV(const TGeoElementRN* ele)
   // This mass should be nuclei mass, not istoopic mass.
   // We should subtract electron masss.
   mass -= ele->AtomicNo()*NucDeEx::Utils::fTDatabasePDG->GetParticle(11)->Mass()*1e3;// GeV2MeV
-  cout << NucDeEx::Utils::fTDatabasePDG->GetParticle(11)->Mass()*1e3 << endl;
+  //cout << NucDeEx::Utils::fTDatabasePDG->GetParticle(11)->Mass()*1e3 << endl; // MeV
 
   double mass_amu = mass/NucDeEx::amu_c2; // MeV to AMU
   if(NucDeEx::Utils::fVerbose>1){

--- a/src/NucDeExDeexcitationBase.cc
+++ b/src/NucDeExDeexcitationBase.cc
@@ -200,6 +200,9 @@ double NucDeExDeexcitationBase::ElementMassInMeV(const TGeoElementRN* ele)
   if(ele==0) return -1; // no profile can be found.
   double mass = ele->MassNo()*NucDeEx::amu_c2
                    + ele->MassEx(); // (MeV)
+  if(NucDeEx::Utils::fVerbose>1){
+    std::cout << "mass including electron (MeV) = " << mass << std::endl;
+  }
   // This mass should be nuclei mass, not istoopic mass.
   // We should subtract electron masss.
   mass -= ele->AtomicNo()*NucDeEx::Utils::fTDatabasePDG->GetParticle(11)->Mass()*1e3;// GeV2MeV

--- a/src/NucDeExDeexcitationTALYS.cc
+++ b/src/NucDeExDeexcitationTALYS.cc
@@ -114,7 +114,7 @@ NucDeExEventInfo NucDeExDeexcitationTALYS::DoDeex(const int Zt, const int Nt,
       DaughterExPoint(&Ex_daughter,&Ex_daughter_point);
 
       // --- Get mass using ROOT libraries
-      if(decay_mode<=2){ // obtained from TDatabasePDG
+      if(decay_mode<=2){ // obtained from TDatabasePDG (gamma, neutron, proton)
         mass_particle = NucDeEx::Utils::fTDatabasePDG->GetParticle(NucDeEx::PDG_particle[decay_mode])->Mass()*1e3;// GeV2MeV
       }else{ // obtained from TGeoElementRN
         int a_particle = (NucDeEx::PDG_particle[decay_mode]%1000)/10;


### PR DESCRIPTION
As explained in https://github.com/SeishoAbe/NucDeEx/issues/12, nucleus mass includes electron mass so far.
This change gives very very negligible impact (almost invisible) on energy spectra of outgoing particle.
Note that  the Q-value is determined by level-to-level BRs, thus, this convension change does not affect to it.